### PR TITLE
Added patch to implement exclusive mode in PulseAudio backend

### DIFF
--- a/patches/Makefile
+++ b/patches/Makefile
@@ -1728,6 +1728,7 @@ winepulse-PulseAudio_Support.ok:
 	$(call APPLY_FILE,winepulse-PulseAudio_Support/0026-winepulse-add-support-for-IMarshal.patch)
 	$(call APPLY_FILE,winepulse-PulseAudio_Support/0027-winepulse-handle-stream-create-failing-correctly.patch)
 	$(call APPLY_FILE,winepulse-PulseAudio_Support/0028-winepulse-expose-audio-devices-directly-to-programs.patch)
+	$(call APPLY_FILE,winepulse-PulseAudio_Support/0029-winepulse-implement-exclusive-mode.patch)
 	@( \
 		echo '+    { "Maarten Lankhorst", "winmm: Load winealsa if winepulse is found.", 1 },'; \
 		echo '+    { "Maarten Lankhorst", "winepulse: Add initial stub for pulseaudio support.", 1 },'; \
@@ -1757,6 +1758,7 @@ winepulse-PulseAudio_Support.ok:
 		echo '+    { "Maarten Lankhorst", "winepulse: add support for IMarshal.", 1 },'; \
 		echo '+    { "Mark Harmstone", "winepulse: handle stream create failing correctly.", 1 },'; \
 		echo '+    { "Mark Harmstone", "winepulse: expose audio devices directly to programs.", 1 },'; \
+		echo '+    { "Mark Harmstone", "winepulse: implement exclusive mode.", 1 },'; \
 	) > winepulse-PulseAudio_Support.ok
 
 # Patchset winex11-CandidateWindowPos

--- a/patches/winepulse-PulseAudio_Support/0029-winepulse-implement-exclusive-mode.patch
+++ b/patches/winepulse-PulseAudio_Support/0029-winepulse-implement-exclusive-mode.patch
@@ -1,0 +1,84 @@
+From 9a90ba84f54a08da2a74329cde6136c6c7aa0fdd Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Tue, 18 Nov 2014 18:35:31 +0000
+Subject: winepulse: implement exclusive mode
+
+---
+ dlls/winepulse.drv/mmdevdrv.c | 45 +++++++++++++++++--------------------------
+ 1 file changed, 18 insertions(+), 27 deletions(-)
+
+diff --git a/dlls/winepulse.drv/mmdevdrv.c b/dlls/winepulse.drv/mmdevdrv.c
+index 368c275..6134850 100644
+--- a/dlls/winepulse.drv/mmdevdrv.c
++++ b/dlls/winepulse.drv/mmdevdrv.c
+@@ -1421,8 +1421,6 @@ static HRESULT WINAPI AudioClient_Initialize(IAudioClient *iface,
+ 
+     if (mode != AUDCLNT_SHAREMODE_SHARED && mode != AUDCLNT_SHAREMODE_EXCLUSIVE)
+         return AUDCLNT_E_NOT_INITIALIZED;
+-    if (mode == AUDCLNT_SHAREMODE_EXCLUSIVE)
+-        return AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED;
+ 
+     if (flags & ~(AUDCLNT_STREAMFLAGS_CROSSPROCESS |
+                 AUDCLNT_STREAMFLAGS_LOOPBACK |
+@@ -1446,27 +1444,26 @@ static HRESULT WINAPI AudioClient_Initialize(IAudioClient *iface,
+     if (FAILED(hr))
+         goto exit;
+ 
+-    if (mode == AUDCLNT_SHAREMODE_SHARED) {
+-        REFERENCE_TIME def = pulse_def_period[This->dataflow == eCapture];
+-        REFERENCE_TIME min = pulse_min_period[This->dataflow == eCapture];
++    REFERENCE_TIME def = pulse_def_period[This->dataflow == eCapture];
++    REFERENCE_TIME min = pulse_min_period[This->dataflow == eCapture];
+ 
+-        /* Switch to low latency mode if below 2 default periods,
+-         * which is 20 ms by default, this will increase the amount
+-         * of interrupts but allows very low latency. In dsound I
+-         * managed to get a total latency of ~8ms, which is well below
+-         * default
+-         */
+-        if (duration < 2 * def)
+-            period = min;
+-        else
+-            period = def;
+-        if (duration < 2 * period)
+-            duration = 2 * period;
++    /* Switch to low latency mode if below 2 default periods,
++     * which is 20 ms by default, this will increase the amount
++     * of interrupts but allows very low latency. In dsound I
++     * managed to get a total latency of ~8ms, which is well below
++     * default
++     */
++    if (duration < 2 * def)
++        period = min;
++    else
++        period = def;
++    if (duration < 2 * period)
++        duration = 2 * period;
++
++    /* Uh oh, really low latency requested.. */
++    if (duration <= 2 * period)
++        period /= 2;
+ 
+-        /* Uh oh, really low latency requested.. */
+-        if (duration <= 2 * period)
+-            period /= 2;
+-    }
+     period_bytes = pa_frame_size(&This->ss) * MulDiv(period, This->ss.rate, 10000000);
+ 
+     if (duration < 20000000)
+@@ -1771,12 +1768,6 @@ static HRESULT WINAPI AudioClient_IsFormatSupported(IAudioClient *iface,
+     else
+         *out = closest;
+ 
+-    /* Winepulse does not currently support exclusive mode, if you know of an
+-     * application that uses it, I will correct this..
+-     */
+-    if (hr == S_OK && exclusive)
+-        return This->dataflow == eCapture ? AUDCLNT_E_UNSUPPORTED_FORMAT : AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED;
+-
+     TRACE("returning: %08x %p\n", hr, out ? *out : NULL);
+     return hr;
+ }
+-- 
+2.0.4
+

--- a/patches/winepulse-PulseAudio_Support/definition
+++ b/patches/winepulse-PulseAudio_Support/definition
@@ -1,2 +1,3 @@
 Fixes: [10495] Support for PulseAudio backend for audio
 Fixes: Allow selection of audio device for PulseAudio backend
+Fixes: Implement exclusive mode in PulseAudio backend


### PR DESCRIPTION
Hi,

This patch implements exclusive mode for winepulse, which is, as far as I can tell, the one major thing it's missing that winealsa has.

Because it's quite hard to get hold of a program which uses exclusive mode in order to test this, I've uploaded a quick and dirty hack of one of the PortAudio examples: http://burntcomma.com/pulse-exclusive.tar.gz. Choose one of the WASAPI input devices and say Y for exclusive mode; it'll record for a few seconds and then play it back.

Thanks
