### PR TITLE
Added patch to fix winepulse segfault

### DIFF
--- a/patches/winepulse-PulseAudio_Support/0030-winepulse-fix-segfault-in-pulse_rd_loop.patch
+++ b/patches/winepulse-PulseAudio_Support/0030-winepulse-fix-segfault-in-pulse_rd_loop.patch
@@ -1,0 +1,24 @@
+From a879d7aa33f4d182d0b60c6991b0eb9e3e0f34fa Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Tue, 18 Nov 2014 18:39:58 +0000
+Subject: winepulse: fix segfault in pulse_rd_loop
+
+---
+ dlls/winepulse.drv/mmdevdrv.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/dlls/winepulse.drv/mmdevdrv.c b/dlls/winepulse.drv/mmdevdrv.c
+index 6134850..37ff7ee 100644
+--- a/dlls/winepulse.drv/mmdevdrv.c
++++ b/dlls/winepulse.drv/mmdevdrv.c
+@@ -592,6 +592,7 @@ static void pulse_rd_loop(ACImpl *This, size_t bytes)
+         size_t src_len, copy, rem = This->capture_period;
+         if (!(p = (ACPacket*)list_head(&This->packet_free_head))) {
+             p = (ACPacket*)list_head(&This->packet_filled_head);
++            if (!p) return;
+             if (!p->discont) {
+                 next = (ACPacket*)p->entry.next;
+                 next->discont = 1;
+-- 
+2.0.4
+

--- a/patches/winepulse-PulseAudio_Support/definition
+++ b/patches/winepulse-PulseAudio_Support/definition
@@ -1,3 +1,4 @@
 Fixes: [10495] Support for PulseAudio backend for audio
 Fixes: Allow selection of audio device for PulseAudio backend
 Fixes: [37042] Implement exclusive mode in PulseAudio backend
+Fixes: Fix segfault in pulse_rd_loop


### PR DESCRIPTION
Patch to fix an intermittent crash in winepulse. Occasionally in pulse_rd_loop both packet_free_head and packet_filled_head will be empty, causing a segfault when list_head returns NULL.
