### PR TITLE
Wrap latest changelog entry lines at 80 columns

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,24 +2,34 @@ wine-staging (1.7.40) UNRELEASED; urgency=low
   * Update dsound fast mixer patchset to use integer math.
   * Various improvements to Debian packaging files, pull request #310.
   * Added patch with stubs for Power[Set|Clear]Request.
-  * Added patch to avoid spam of FIXME messages for PsLookupProcessByProcessId stub.
+  * Added patch to avoid spam of FIXME messages for PsLookupProcessByProcessId
+    stub.
   * Added patch to implement empty enumerator for IWiaDevMgr::EnumDeviceInfo.
   * Added patch to fix handling of ANSI NTLM credentials.
   * Added patch to fix compatibility of Uplay with gnutls28.
-  * Added patches for Environmental Audio Extensions (EAX), pull request #311 from Mark Harmstone.
-  * Added patch to fix return value of WS_select in case of EINTR during timeout.
+  * Added patches for Environmental Audio Extensions (EAX), pull request #311
+    from Mark Harmstone.
+  * Added patch to fix return value of WS_select in case of EINTR during
+    timeout.
   * Added patch to fix calculation of 3D sound source.
   * Added patch for stub of fltmgr.sys (filter manager driver).
   * Added patch to return correct device type for cd devices without medium.
   * Added patch to fix device paths in HKLM\SYSTEM\MountedDevices.
-  * Added patch to show unmounted devices in winecfg and allow changing the unix path.
-  * Added patch for support of 8bpp grayscale TIFF images with 8bpp alpha channel (replaces previous stub).
-  * Removed patch to fix regression causing black screen on startup (accepted upstream).
+  * Added patch to show unmounted devices in winecfg and allow changing the
+    unix path.
+  * Added patch for support of 8bpp grayscale TIFF images with 8bpp alpha
+    channel (replaces previous stub).
+  * Removed patch to fix regression causing black screen on startup (accepted
+    upstream).
   * Removed patch to fix edge cases in TOOLTIPS_GetTipText (fixed upstream).
-  * Removed patch for IConnectionPoint/INetworkListManagerEvents stub interface (accepted upstream).
-  * Removed patch to fix race-condition when closing browseui IProcessDialog (accepted upstream).
-  * Removed patch with tests for GetFinalPathNameByHandleA/W (accepted upstream).
-  * Removed patch to emulate 'mov Eb, Gb' instruction on x86 processor architecture (accepted upstream).
+  * Removed patch for IConnectionPoint/INetworkListManagerEvents stub
+    interface (accepted upstream).
+  * Removed patch to fix race-condition when closing browseui IProcessDialog
+    (accepted upstream).
+  * Removed patch with tests for GetFinalPathNameByHandleA/W (accepted
+    upstream).
+  * Removed patch to emulate 'mov Eb, Gb' instruction on x86 processor
+    architecture (accepted upstream).
   * Removed patches for Setup*Log() functions (accepted upstream).
   * Removed tests for job objects (accepted upstream).
  -- Sebastian Lackner <sebastian@fds-team.de>  Mon, 23 Mar 2015 16:12:20 +0100


### PR DESCRIPTION
Fixes debian-changelog-line-too-long warnings:
https://lintian.debian.org/tags/debian-changelog-line-too-long.html