### PR TITLE
Added patches for msstyles v4 support in uxtheme.

### DIFF
--- a/patches/uxtheme-MSStylesV4/0001-winecfg-Copy-MUI-files-when-theme-installed.patch
+++ b/patches/uxtheme-MSStylesV4/0001-winecfg-Copy-MUI-files-when-theme-installed.patch
@@ -1,0 +1,133 @@
+From 6e95ee7afa4ac109eb06181719e32c1df36c3fc9 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 19:09:37 +0100
+Subject: [PATCH 01/19] winecfg: Copy MUI files when theme installed.
+
+---
+ programs/winecfg/theme.c | 81 +++++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 74 insertions(+), 7 deletions(-)
+
+diff --git a/programs/winecfg/theme.c b/programs/winecfg/theme.c
+index 8ffc9bb..1a25643 100644
+--- a/programs/winecfg/theme.c
++++ b/programs/winecfg/theme.c
+@@ -661,8 +661,14 @@ static void on_theme_install(HWND dialog)
+   {
+       static const WCHAR themesSubdir[] = { '\\','T','h','e','m','e','s',0 };
+       static const WCHAR backslash[] = { '\\',0 };
+-      WCHAR themeFilePath[MAX_PATH];
++      static const WCHAR wildcard[] = { '\\','*',0 };
++      static const WCHAR mui_ext[] = { '.','m','u','i',0 };
++      WCHAR themeFilePath[MAX_PATH], searchpath[MAX_PATH], muipath[MAX_PATH], muidest[MAX_PATH], origfiletitle[MAX_PATH];
++      WCHAR *srclist, *destlist;
++      unsigned int muipathlen, muidestlen, srclistlen, destlistlen;
+       SHFILEOPSTRUCTW shfop;
++      HANDLE fff;
++      WIN32_FIND_DATAW finddata;
+ 
+       if (FAILED (SHGetFolderPathW (NULL, CSIDL_RESOURCES|CSIDL_FLAG_CREATE, NULL, 
+           SHGFP_TYPE_CURRENT, themeFilePath))) return;
+@@ -674,6 +680,16 @@ static void on_theme_install(HWND dialog)
+           return;
+       }
+ 
++      strcpyW(searchpath, file);
++      PathRemoveFileSpecW(searchpath);
++
++      strcpyW(muipath, searchpath);
++      strcatW(muipath, backslash);
++      muipathlen = strlenW(muipath);
++
++      strcatW(searchpath, wildcard);
++
++      strcpyW(origfiletitle, filetitle);
+       PathRemoveExtensionW (filetitle);
+ 
+       /* Construct path into which the theme file goes */
+@@ -686,19 +702,67 @@ static void on_theme_install(HWND dialog)
+ 
+       /* Append theme file name itself */
+       lstrcatW (themeFilePath, backslash);
++
++      strcpyW (muidest, themeFilePath);
++      muidestlen = strlenW(muidest);
++
+       lstrcatW (themeFilePath, PathFindFileNameW (file));
+-      /* SHFileOperation() takes lists as input, so double-nullterminate */
+-      themeFilePath[lstrlenW (themeFilePath)+1] = 0;
+-      file[lstrlenW (file)+1] = 0;
++
++      srclistlen = strlenW(file) + 1;
++      srclist = HeapAlloc(GetProcessHeap(), 0, (srclistlen + 1) * sizeof(WCHAR));
++      memcpy(srclist, file, srclistlen * sizeof(WCHAR));
++      srclist[srclistlen] = 0;
++
++      destlistlen = strlenW(themeFilePath) + 1;
++      destlist = HeapAlloc(GetProcessHeap(), 0, (destlistlen + 1) * sizeof(WCHAR));
++      memcpy(destlist, themeFilePath, destlistlen * sizeof(WCHAR));
++      destlist[destlistlen] = 0;
++
++      fff = FindFirstFileW(searchpath, &finddata);
++      do {
++          if (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY && finddata.cFileName[0] != '.')
++          {
++              muipath[muipathlen] = 0;
++              strcatW(muipath, finddata.cFileName);
++              strcatW(muipath, backslash);
++              strcatW(muipath, origfiletitle);
++              strcatW(muipath, mui_ext);
++
++              if (GetFileAttributesW(muipath) != INVALID_FILE_ATTRIBUTES)
++              {
++                  unsigned int srclen = strlenW(muipath) + 1, destlen;
++
++                  muidest[muidestlen] = 0;
++                  strcatW(muidest, finddata.cFileName);
++                  SHCreateDirectoryExW (dialog, muidest, NULL);
++
++                  strcatW(muidest, backslash);
++                  strcatW(muidest, origfiletitle);
++                  strcatW(muidest, mui_ext);
++                  destlen = strlenW(muidest) + 1;
++
++                  srclist = HeapReAlloc(GetProcessHeap(), 0, srclist, (srclistlen + srclen + 1) * sizeof(WCHAR));
++                  memcpy(&srclist[srclistlen], muipath, srclen * sizeof(WCHAR));
++                  srclistlen += srclen;
++                  srclist[srclistlen] = 0;
++
++                  destlist = HeapReAlloc(GetProcessHeap(), 0, destlist, (destlistlen + destlen + 1) * sizeof(WCHAR));
++                  memcpy(&destlist[destlistlen], muidest, destlen * sizeof(WCHAR));
++                  destlistlen += destlen;
++                  destlist[destlistlen] = 0;
++              }
++          }
++      } while (FindNextFileW(fff, &finddata));
++      FindClose(fff);
+ 
+       /* Do the copying */
+       WINE_TRACE("copying: %s -> %s\n", wine_dbgstr_w (file), 
+           wine_dbgstr_w (themeFilePath));
+       shfop.hwnd = dialog;
+       shfop.wFunc = FO_COPY;
+-      shfop.pFrom = file;
+-      shfop.pTo = themeFilePath;
+-      shfop.fFlags = FOF_NOCONFIRMMKDIR;
++      shfop.pFrom = srclist;
++      shfop.pTo = destlist;
++      shfop.fFlags = FOF_NOCONFIRMMKDIR | FOF_MULTIDESTFILES;
+       if (SHFileOperationW (&shfop) == 0)
+       {
+           scan_theme_files();
+@@ -717,6 +781,9 @@ static void on_theme_install(HWND dialog)
+       }
+       else
+           WINE_TRACE("copy operation failed\n");
++
++      HeapFree(GetProcessHeap(), 0, srclist);
++      HeapFree(GetProcessHeap(), 0, destlist);
+   }
+   else WINE_TRACE("user cancelled\n");
+ }
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0002-uxtheme-Load-theme-MUI-file.patch
+++ b/patches/uxtheme-MSStylesV4/0002-uxtheme-Load-theme-MUI-file.patch
@@ -1,0 +1,175 @@
+From 47cc6bfb75acca58c2dc9f01829b5069d693bc76 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 20:18:58 +0100
+Subject: [PATCH 02/19] uxtheme: Load theme MUI file.
+
+---
+ dlls/uxtheme/msstyles.c | 97 ++++++++++++++++++++++++++++++++++++++++++++++++-
+ dlls/uxtheme/msstyles.h |  1 +
+ 2 files changed, 97 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index e62b95d..b022edc 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -48,6 +48,8 @@ static BOOL MSSTYLES_GetNextToken(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LP
+ static void MSSTYLES_ParseThemeIni(PTHEME_FILE tf, BOOL setMetrics);
+ static HRESULT MSSTYLES_GetFont (LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LPCWSTR *lpValEnd, LOGFONTW* logfont);
+ 
++INT WINAPI GetSystemDefaultLocaleName(LPWSTR localename, INT len);
++
+ extern int alphaBlendMode;
+ 
+ #define MSSTYLES_VERSION 0x0003
+@@ -60,6 +62,93 @@ static PTHEME_FILE tfActiveTheme;
+ 
+ /***********************************************************************/
+ 
++static HMODULE try_opening_mui_file(LPCWSTR locale, LPCWSTR path, LPCWSTR filename)
++{
++    WCHAR muipath[MAX_PATH];
++    static WCHAR backslash[] = {'\\',0};
++    static WCHAR muiext[] = {'.','m','u','i',0};
++
++    strcpyW(muipath, path);
++    strcatW(muipath, locale);
++    strcatW(muipath, backslash);
++    strcatW(muipath, filename);
++    strcatW(muipath, muiext);
++
++    return LoadLibraryExW(muipath, NULL, LOAD_LIBRARY_AS_DATAFILE);
++}
++
++static inline void get_lang_from_locale(WCHAR* locale, WCHAR* lang)
++{
++    static WCHAR dash[] = {'-',0};
++    WCHAR* dashstr = strstrW(locale, dash);
++
++    if (dashstr) {
++        memcpy(lang, locale, (dashstr - locale)*sizeof(WCHAR));
++        lang[dashstr - locale] = 0;
++    } else {
++        strcpyW(lang, locale);
++    }
++}
++
++static HMODULE load_mui_file(LPCWSTR lpThemeFile)
++{
++    int i, len = strlenW(lpThemeFile);
++    WCHAR path[MAX_PATH], locale[LOCALE_NAME_MAX_LENGTH], searchstring[MAX_PATH], lang[LOCALE_NAME_MAX_LENGTH];
++    const WCHAR* filename = NULL;
++    HMODULE muifile;
++    HANDLE fff;
++    WIN32_FIND_DATAW finddata;
++
++    static WCHAR wildcard[] = {'*',0};
++    static WCHAR default_locale[] = {'e','n','-','U','S',0};
++
++    for (i = len - 1; i >= 0; i--) {
++        if (lpThemeFile[i] == '\\' || lpThemeFile[i] == '/') {
++            memcpy(path, lpThemeFile, i * sizeof(WCHAR));
++            path[i] = '\\';
++            path[i+1] = 0;
++            filename = &lpThemeFile[i+1];
++            break;
++        }
++    }
++
++    /* Just filename, no path */
++    if (i == -1) {
++        path[0] = 0;
++        filename = lpThemeFile;
++    }
++
++    if (!GetSystemDefaultLocaleName(locale, sizeof(locale)/sizeof(*locale)))
++        goto failsafe;
++
++    if ((muifile = try_opening_mui_file(locale, path, filename)))
++        return muifile;
++
++    /* If exact language match not found, try the available sublangs */
++    get_lang_from_locale(locale, lang);
++    strcpyW(searchstring, path);
++    strcatW(searchstring, wildcard);
++    fff = FindFirstFileW(searchstring, &finddata);
++
++    do {
++        if (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY && finddata.cFileName[0] != '.') {
++            WCHAR filelang[MAX_PATH];
++
++            get_lang_from_locale(finddata.cFileName, filelang);
++
++            if (!strcmpiW(lang, filelang) && (muifile = try_opening_mui_file(finddata.cFileName, path, filename))) {
++                FindClose(fff);
++                return muifile;
++            }
++        }
++    } while (FindNextFileW(fff, &finddata));
++
++    FindClose(fff);
++
++failsafe:
++    return try_opening_mui_file(default_locale, path, filename);
++}
++
+ /**********************************************************************
+  *      MSSTYLES_OpenThemeFile
+  *
+@@ -77,7 +166,7 @@ static PTHEME_FILE tfActiveTheme;
+  */
+ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWSTR pszSizeName, PTHEME_FILE *tf)
+ {
+-    HMODULE hTheme;
++    HMODULE hTheme, hMUIFile = NULL;
+     HRSRC hrsc;
+     HRESULT hr = S_OK;
+     static const WCHAR szPackThemVersionResource[] = {
+@@ -118,6 +207,9 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
+         goto invalid_theme;
+     }
++
++    hMUIFile = load_mui_file(lpThemeFile);
++
+     version = *(WORD*)LoadResource(hTheme, hrsc);
+     if(version != MSSTYLES_VERSION)
+     {
+@@ -177,6 +269,7 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+ 
+     *tf = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(THEME_FILE));
+     (*tf)->hTheme = hTheme;
++    (*tf)->hMUIFile = hMUIFile;
+     
+     GetFullPathNameW(lpThemeFile, MAX_PATH, (*tf)->szThemeFile, NULL);
+     
+@@ -189,6 +282,7 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+ 
+ invalid_theme:
+     if(hTheme) FreeLibrary(hTheme);
++    if(hMUIFile) FreeLibrary(hMUIFile);
+     return hr;
+ }
+ 
+@@ -203,6 +297,7 @@ void MSSTYLES_CloseThemeFile(PTHEME_FILE tf)
+         tf->dwRefCount--;
+         if(!tf->dwRefCount) {
+             if(tf->hTheme) FreeLibrary(tf->hTheme);
++            if(tf->hMUIFile) FreeLibrary(tf->hMUIFile);
+             if(tf->classes) {
+                 while(tf->classes) {
+                     PTHEME_CLASS pcls = tf->classes;
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 0b7e1ab..6dab7f8 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -70,6 +70,7 @@ typedef struct _THEME_IMAGE {
+ typedef struct _THEME_FILE {
+     DWORD dwRefCount;
+     HMODULE hTheme;
++    HMODULE hMUIFile;
+     WCHAR szThemeFile[MAX_PATH];
+     LPWSTR pszAvailColors;
+     LPWSTR pszAvailSizes;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0003-uxtheme-Allow-loading-of-v4-msstyles-files.patch
+++ b/patches/uxtheme-MSStylesV4/0003-uxtheme-Allow-loading-of-v4-msstyles-files.patch
@@ -1,0 +1,257 @@
+From f4c83581641a0c0c3c6ecc34428cb6e0bf303e6a Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 21:12:23 +0100
+Subject: [PATCH 03/19] uxtheme: Allow loading of v4 msstyles files.
+
+---
+ dlls/uxtheme/msstyles.c | 152 +++++++++++++++++++++++++++++++++---------------
+ dlls/uxtheme/msstyles.h |   9 +++
+ 2 files changed, 115 insertions(+), 46 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index b022edc..76c069b 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -52,8 +52,6 @@ INT WINAPI GetSystemDefaultLocaleName(LPWSTR localename, INT len);
+ 
+ extern int alphaBlendMode;
+ 
+-#define MSSTYLES_VERSION 0x0003
+-
+ static const WCHAR szThemesIniResource[] = {
+     't','h','e','m','e','s','_','i','n','i','\0'
+ };
+@@ -178,6 +176,9 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+     static const WCHAR szSizeNamesResource[] = {
+         'S','I','Z','E','N','A','M','E','S','\0'
+     };
++    static const WCHAR szVMAPResource[] = {
++        'V','M','A','P','\0'
++    };
+ 
+     WORD version;
+     DWORD versize;
+@@ -186,6 +187,7 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+     LPWSTR pszSizes;
+     LPWSTR pszSelectedSize = NULL;
+     LPWSTR tmp;
++    variant_map vmap;
+ 
+     TRACE("Opening %s\n", debugstr_w(lpThemeFile));
+ 
+@@ -211,60 +213,111 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+     hMUIFile = load_mui_file(lpThemeFile);
+ 
+     version = *(WORD*)LoadResource(hTheme, hrsc);
+-    if(version != MSSTYLES_VERSION)
++    if(version != 3 && version != 4)
+     {
+         TRACE("Version of theme file is unsupported: 0x%04x\n", version);
+         hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
+         goto invalid_theme;
+     }
+ 
+-    if(!(hrsc = FindResourceW(hTheme, MAKEINTRESOURCEW(1), szColorNamesResource))) {
+-        TRACE("Color names resource not found\n");
+-        hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
+-        goto invalid_theme;
+-    }
+-    pszColors = LoadResource(hTheme, hrsc);
++    if (version == 3) {
++        if(!(hrsc = FindResourceW(hTheme, MAKEINTRESOURCEW(1), szColorNamesResource))) {
++            TRACE("Color names resource not found\n");
++            hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
++            goto invalid_theme;
++        }
++        pszColors = LoadResource(hTheme, hrsc);
+ 
+-    if(!(hrsc = FindResourceW(hTheme, MAKEINTRESOURCEW(1), szSizeNamesResource))) {
+-        TRACE("Size names resource not found\n");
+-        hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
+-        goto invalid_theme;
+-    }
+-    pszSizes = LoadResource(hTheme, hrsc);
+-
+-    /* Validate requested color against what's available from the theme */
+-    if(pszColorName) {
+-        tmp = pszColors;
+-        while(*tmp) {
+-            if(!lstrcmpiW(pszColorName, tmp)) {
+-                pszSelectedColor = tmp;
+-                break;
++        if(!(hrsc = FindResourceW(hTheme, MAKEINTRESOURCEW(1), szSizeNamesResource))) {
++            TRACE("Size names resource not found\n");
++            hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
++            goto invalid_theme;
++        }
++        pszSizes = LoadResource(hTheme, hrsc);
++
++        /* Validate requested color against what's available from the theme */
++        if(pszColorName) {
++            tmp = pszColors;
++            while(*tmp) {
++                if(!lstrcmpiW(pszColorName, tmp)) {
++                    pszSelectedColor = tmp;
++                    break;
++                }
++                tmp += lstrlenW(tmp)+1;
+             }
+-            tmp += lstrlenW(tmp)+1;
+         }
+-    }
+-    else
+-        pszSelectedColor = pszColors; /* Use the default color */
+-
+-    /* Validate requested size against what's available from the theme */
+-    if(pszSizeName) {
+-        tmp = pszSizes;
+-        while(*tmp) {
+-            if(!lstrcmpiW(pszSizeName, tmp)) {
+-                pszSelectedSize = tmp;
+-                break;
++        else
++            pszSelectedColor = pszColors; /* Use the default color */
++
++        /* Validate requested size against what's available from the theme */
++        if(pszSizeName) {
++            tmp = pszSizes;
++            while(*tmp) {
++                if(!lstrcmpiW(pszSizeName, tmp)) {
++                    pszSelectedSize = tmp;
++                    break;
++                }
++                tmp += lstrlenW(tmp)+1;
+             }
+-            tmp += lstrlenW(tmp)+1;
+         }
+-    }
+-    else
+-        pszSelectedSize = pszSizes; /* Use the default size */
++        else
++            pszSelectedSize = pszSizes; /* Use the default size */
++
++        if(!pszSelectedColor || !pszSelectedSize) {
++            TRACE("Requested color/size (%s/%s) not found in theme\n",
++                debugstr_w(pszColorName), debugstr_w(pszSizeName));
++            hr = E_PROP_ID_UNSUPPORTED;
++            goto invalid_theme;
++        }
++    } else {
++        const BYTE* vmapdata;
++        int i;
++        DWORD len;
++
++        if(!(hrsc = FindResourceW(hTheme, szVMAPResource, szVMAPResource))) {
++            TRACE("VMAP resource not found\n");
++            hr = HRESULT_FROM_WIN32(ERROR_BAD_FORMAT);
++            goto invalid_theme;
++        }
+ 
+-    if(!pszSelectedColor || !pszSelectedSize) {
+-        TRACE("Requested color/size (%s/%s) not found in theme\n",
+-              debugstr_w(pszColorName), debugstr_w(pszSizeName));
+-        hr = E_PROP_ID_UNSUPPORTED;
+-        goto invalid_theme;
++        vmapdata = LoadResource(hTheme, hrsc);
++
++        i = 0;
++
++        memcpy(&len, &vmapdata[i], sizeof(DWORD));
++        i += sizeof(DWORD);
++        vmap.name = (LPCWSTR)&vmapdata[i];
++        i += len * sizeof(WCHAR);
++        if (i%4 != 0) { i += 4-(i%4); }
++
++        memcpy(&len, &vmapdata[i], sizeof(DWORD));
++        i += sizeof(DWORD);
++        vmap.size = (LPCWSTR)&vmapdata[i];
++        i += len * sizeof(WCHAR);
++        if (i%4 != 0) { i += 4-(i%4); }
++
++        if (pszSizeName && strcmpiW(pszSizeName, vmap.size)) {
++            WARN("Requested size %s not found in theme (%s)\n", debugstr_w(pszSizeName), debugstr_w(vmap.size));
++            hr = E_PROP_ID_UNSUPPORTED;
++            goto invalid_theme;
++        } else
++            pszSelectedSize = (LPWSTR)vmap.size;
++
++        memcpy(&len, &vmapdata[i], sizeof(DWORD));
++        i += sizeof(DWORD);
++        vmap.colour = (LPCWSTR)&vmapdata[i];
++        i += len * sizeof(WCHAR);
++        if (i%4 != 0) { i += 4-(i%4); }
++
++        if (pszColorName && strcmpiW(pszColorName, vmap.colour)) {
++            WARN("Requested colour %s not found in theme\n", debugstr_w(pszColorName));
++            hr = E_PROP_ID_UNSUPPORTED;
++            goto invalid_theme;
++        } else
++            pszSelectedColor = (LPWSTR)vmap.colour;
++
++        pszColors = pszSelectedColor;
++        pszSizes = pszSelectedSize;
+     }
+ 
+     *tf = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(THEME_FILE));
+@@ -278,6 +331,11 @@ HRESULT MSSTYLES_OpenThemeFile(LPCWSTR lpThemeFile, LPCWSTR pszColorName, LPCWST
+     (*tf)->pszSelectedColor = pszSelectedColor;
+     (*tf)->pszSelectedSize = pszSelectedSize;
+     (*tf)->dwRefCount = 1;
++    (*tf)->version = version;
++
++    if (version == 4)
++        memcpy(&(*tf)->vmap, &vmap, sizeof(vmap));
++
+     return S_OK;
+ 
+ invalid_theme:
+@@ -342,8 +400,10 @@ HRESULT MSSTYLES_SetActiveTheme(PTHEME_FILE tf, BOOL setMetrics)
+     if (tfActiveTheme)
+     {
+ 	tfActiveTheme->dwRefCount++;
+-	if(!tfActiveTheme->classes)
+-	    MSSTYLES_ParseThemeIni(tfActiveTheme, setMetrics);
++        if (tfActiveTheme->version != 4) {
++            if(!tfActiveTheme->classes)
++                MSSTYLES_ParseThemeIni(tfActiveTheme, setMetrics);
++        }
+     }
+     return S_OK;
+ }
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 6dab7f8..c72ac8d 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -67,6 +67,12 @@ typedef struct _THEME_IMAGE {
+     struct _THEME_IMAGE *next;
+ } THEME_IMAGE, *PTHEME_IMAGE;
+ 
++typedef struct {
++    LPCWSTR name;
++    LPCWSTR size;
++    LPCWSTR colour;
++} variant_map;
++
+ typedef struct _THEME_FILE {
+     DWORD dwRefCount;
+     HMODULE hTheme;
+@@ -74,6 +80,7 @@ typedef struct _THEME_FILE {
+     WCHAR szThemeFile[MAX_PATH];
+     LPWSTR pszAvailColors;
+     LPWSTR pszAvailSizes;
++    DWORD version;
+ 
+     LPWSTR pszSelectedColor;
+     LPWSTR pszSelectedSize;
+@@ -81,6 +88,8 @@ typedef struct _THEME_FILE {
+     PTHEME_CLASS classes;
+     PTHEME_PROPERTY metrics;
+     PTHEME_IMAGE images;
++
++    variant_map vmap;
+ } THEME_FILE, *PTHEME_FILE;
+ 
+ typedef struct _UXINI_FILE *PUXINI_FILE;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0004-uxtheme-Load-v4-class-map.patch
+++ b/patches/uxtheme-MSStylesV4/0004-uxtheme-Load-v4-class-map.patch
@@ -1,0 +1,126 @@
+From b6003b3faa852e0bafda4ea8e04af0f751c879f2 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 21:18:59 +0100
+Subject: [PATCH 04/19] uxtheme: Load v4 class map.
+
+---
+ dlls/uxtheme/msstyles.c | 61 ++++++++++++++++++++++++++++++++++++++++++++++++-
+ dlls/uxtheme/msstyles.h |  2 ++
+ 2 files changed, 62 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 76c069b..40a0d4c 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -46,6 +46,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(uxtheme);
+ static BOOL MSSTYLES_GetNextInteger(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LPCWSTR *lpValEnd, int *value);
+ static BOOL MSSTYLES_GetNextToken(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LPCWSTR *lpValEnd, LPWSTR lpBuff, DWORD buffSize);
+ static void MSSTYLES_ParseThemeIni(PTHEME_FILE tf, BOOL setMetrics);
++static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics);
+ static HRESULT MSSTYLES_GetFont (LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LPCWSTR *lpValEnd, LOGFONTW* logfont);
+ 
+ INT WINAPI GetSystemDefaultLocaleName(LPWSTR localename, INT len);
+@@ -382,6 +383,8 @@ void MSSTYLES_CloseThemeFile(PTHEME_FILE tf)
+                 DeleteObject (img->image);
+                 HeapFree (GetProcessHeap(), 0, img);
+             }
++            if (tf->classesv4)
++                HeapFree(GetProcessHeap(), 0, tf->classesv4);
+             HeapFree(GetProcessHeap(), 0, tf);
+         }
+     }
+@@ -400,7 +403,10 @@ HRESULT MSSTYLES_SetActiveTheme(PTHEME_FILE tf, BOOL setMetrics)
+     if (tfActiveTheme)
+     {
+ 	tfActiveTheme->dwRefCount++;
+-        if (tfActiveTheme->version != 4) {
++        if (tfActiveTheme->version == 4) {
++            if (!tfActiveTheme->classesv4)
++                MSSTYLES_ParseV4Theme(tfActiveTheme, setMetrics);
++        } else {
+             if(!tfActiveTheme->classes)
+                 MSSTYLES_ParseThemeIni(tfActiveTheme, setMetrics);
+         }
+@@ -832,6 +838,54 @@ static PTHEME_PROPERTY MSSTYLES_AddMetric(PTHEME_FILE tf, int iPropertyPrimitive
+     return cur;
+ }
+ 
++void MSSTYLES_ParseV4ClassMap(PTHEME_FILE tf)
++{
++    HRSRC hrsc;
++    DWORD size;
++    WCHAR* buf;
++    int i, j;
++
++    static const WCHAR CMAPResource[] = {
++        'C','M','A','P',0
++    };
++
++    tf->numclassesv4 = 0;
++    if(!(hrsc = FindResourceW(tf->hTheme, CMAPResource, CMAPResource))) {
++        WARN("No CMAP resource found\n");
++        return;
++    }
++
++    size = SizeofResource(tf->hTheme, hrsc);
++
++    buf = (WCHAR*)LoadResource(tf->hTheme, hrsc);
++    if (!buf) {
++        WARN("Could not open class map\n");
++        return;
++    }
++
++    for (i = 1; i < size/2; i++) {
++        if (buf[i] == 0 && buf[i-1] != 0) {
++            tf->numclassesv4++;
++        }
++    }
++
++    if (tf->numclassesv4 == 0) {
++        WARN("No classes found\n");
++        return;
++    }
++
++    tf->classesv4 = HeapAlloc(GetProcessHeap(), 0, tf->numclassesv4 * sizeof(WCHAR*));
++
++    j = 0;
++    tf->classesv4[0] = buf;
++    for (i = 1; i < size/2; i++) {
++        if (buf[i] != 0 && buf[i-1] == 0) {
++            j++;
++            tf->classesv4[j] = &buf[i];
++        }
++    }
++}
++
+ /* Color-related state for theme ini parsing */
+ struct PARSECOLORSTATE
+ {
+@@ -1011,6 +1065,11 @@ static void parse_apply_nonclient (struct PARSENONCLIENTSTATE* state)
+     }
+ }
+ 
++static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics)
++{
++    MSSTYLES_ParseV4ClassMap(tf);
++}
++
+ /***********************************************************************
+  *      MSSTYLES_ParseThemeIni
+  *
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index c72ac8d..cc6deea 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -89,6 +89,8 @@ typedef struct _THEME_FILE {
+     PTHEME_PROPERTY metrics;
+     PTHEME_IMAGE images;
+ 
++    int numclassesv4;
++    WCHAR** classesv4;
+     variant_map vmap;
+ } THEME_FILE, *PTHEME_FILE;
+ 
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0005-uxtheme-Parse-v4-string-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0005-uxtheme-Parse-v4-string-properties.patch
@@ -1,0 +1,385 @@
+From 9557e99cf9d9b6e1c294c80a09969e052bf7deed Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 21:50:02 +0100
+Subject: [PATCH 05/19] uxtheme: Parse v4 string properties.
+
+---
+ dlls/uxtheme/msstyles.c | 174 +++++++++++++++++++++++++++++++++++++++++++++++-
+ dlls/uxtheme/msstyles.h |   2 +
+ dlls/uxtheme/property.c |  61 +++++++++++------
+ 3 files changed, 214 insertions(+), 23 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 40a0d4c..a65e94f 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -59,6 +59,17 @@ static const WCHAR szThemesIniResource[] = {
+ 
+ static PTHEME_FILE tfActiveTheme;
+ 
++typedef struct {
++    DWORD property;
++    DWORD type;
++    DWORD classnum;
++    DWORD part;
++    DWORD state;
++    DWORD resref;
++    DWORD unk2;
++    DWORD datalen;
++} property_header;
++
+ /***********************************************************************/
+ 
+ static HMODULE try_opening_mui_file(LPCWSTR locale, LPCWSTR path, LPCWSTR filename)
+@@ -886,6 +897,109 @@ void MSSTYLES_ParseV4ClassMap(PTHEME_FILE tf)
+     }
+ }
+ 
++void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
++{
++    HRSRC hrsc;
++    DWORD size;
++    BYTE* buf;
++    property_header* ph;
++    int i;
++    PTHEME_CLASS cls;
++    PTHEME_PARTSTATE ps;
++    BOOL globals;
++
++    static const WCHAR VariantResource[] = {
++        'V','A','R','I','A','N','T',0
++    };
++
++    static const WCHAR RMAPResource[] = {
++        'R','M','A','P',0
++    };
++
++    static const WCHAR globalsW[] = { 'g','l','o','b','a','l','s',0 };
++
++    if(!(hrsc = FindResourceW(tf->hTheme, variant_name ? variant_name : RMAPResource, variant_name ? VariantResource : RMAPResource))) {
++        WARN("Variant resource not found\n");
++        return;
++    }
++
++    size = SizeofResource(tf->hTheme, hrsc);
++
++    buf = (BYTE*)LoadResource(tf->hTheme, hrsc);
++    if (!buf) {
++        WARN("Could not open variant resource\n");
++        return;
++    }
++
++    i = 0;
++    cls = NULL;
++    while (i < size) {
++        PTHEME_PROPERTY prop;
++
++        ph = (property_header*)&buf[i];
++        i += sizeof(property_header);
++
++        if (cls == NULL || ph->classnum != cls->classv4) {
++            WCHAR szAppName[255], szClassName[255];
++            WCHAR* colon;
++
++            colon = strchrW(tf->classesv4[ph->classnum], ':');
++
++            if (colon) {
++                memcpy(szAppName, tf->classesv4[ph->classnum], (colon - tf->classesv4[ph->classnum]) * sizeof(WCHAR));
++                szAppName[(colon - tf->classesv4[ph->classnum])] = 0;
++
++                colon++;
++                if (colon[0] == ':')
++                    colon++;
++
++                strcpyW(szClassName, colon);
++            } else {
++                szAppName[0] = 0;
++                strcpyW(szClassName, tf->classesv4[ph->classnum]);
++            }
++
++            globals = !strcmpiW(tf->classesv4[ph->classnum], globalsW);
++
++            cls = MSSTYLES_AddClass(tf, szAppName, szClassName);
++            ps = MSSTYLES_AddPartState(cls, ph->part, ph->state);
++            cls->classv4 = ph->classnum;
++        } else if (ph->part != ps->iPartId || ph->state != ps->iStateId)
++            ps = MSSTYLES_AddPartState(cls, ph->part, ph->state);
++
++        prop = MSSTYLES_AddProperty(ps, ph->type, ph->property, NULL, 0, globals);
++        prop->version = tf->version;
++
++        if (ph->resref == 0) {
++            switch (ph->type) {
++                case TMT_STRING:
++                    prop->lpValue = (LPCWSTR)&buf[i];
++                    prop->dwValueLen = ph->datalen / sizeof(WCHAR);
++                break;
++
++                default:
++                    FIXME("Unprocessed non-resource property type %u\n", ph->type);
++                break;
++            }
++            i += ph->datalen;
++        } else {
++            switch (ph->type) {
++                case TMT_STRING:
++                    LoadStringW(tf->hMUIFile, ph->resref, (LPWSTR)&prop->lpValue, 0);
++                    prop->dwValueLen = (ph->datalen - 1) / sizeof(WCHAR);
++                break;
++
++                default:
++                    FIXME("Unprocessed resource property type %u\n", ph->type);
++                break;
++            }
++        }
++
++        if (i % 8 != 0)
++            i += 8 - (i%8);
++    }
++}
++
+ /* Color-related state for theme ini parsing */
+ struct PARSECOLORSTATE
+ {
+@@ -1065,9 +1179,26 @@ static void parse_apply_nonclient (struct PARSENONCLIENTSTATE* state)
+     }
+ }
+ 
++static BOOL MSSTYLES_GetVariantName(PTHEME_FILE tf, WCHAR* variant_name)
++{
++    if (!strcmpiW(tf->pszSelectedSize, tf->vmap.size) && !strcmpiW(tf->pszSelectedColor, tf->vmap.colour)) {
++        strcpyW(variant_name, tf->vmap.name);
++        return TRUE;
++    } else
++        return FALSE;
++}
++
+ static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics)
+ {
++    WCHAR variant_name[255];
++
++    if (!MSSTYLES_GetVariantName(tf, variant_name)) {
++        WARN("Could not get variant name for selected size and colour\n");
++        return;
++    }
++
+     MSSTYLES_ParseV4ClassMap(tf);
++    MSSTYLES_ParseV4Properties(tf, variant_name);
+ }
+ 
+ /***********************************************************************
+@@ -1162,7 +1293,8 @@ static void MSSTYLES_ParseThemeIni(PTHEME_FILE tf, BOOL setMetrics)
+             while((lpName=UXINI_GetNextValue(ini, &dwLen, &lpValue, &dwValueLen))) {
+                 lstrcpynW(szPropertyName, lpName, min(dwLen+1, sizeof(szPropertyName)/sizeof(szPropertyName[0])));
+                 if(MSSTYLES_LookupProperty(szPropertyName, &iPropertyPrimitive, &iPropertyId)) {
+-                    MSSTYLES_AddProperty(ps, iPropertyPrimitive, iPropertyId, lpValue, dwValueLen, isGlobal);
++                    PTHEME_PROPERTY prop = MSSTYLES_AddProperty(ps, iPropertyPrimitive, iPropertyId, lpValue, dwValueLen, isGlobal);
++                    prop->version = tf->version;
+                 }
+                 else {
+                     TRACE("Unknown property %s\n", debugstr_w(szPropertyName));
+@@ -1416,6 +1548,11 @@ static BOOL MSSTYLES_GetNextToken(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LP
+  */
+ HRESULT MSSTYLES_GetPropertyBool(PTHEME_PROPERTY tp, BOOL *pfVal)
+ {
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     *pfVal = FALSE;
+     if(*tp->lpValue == 't' || *tp->lpValue == 'T')
+         *pfVal = TRUE;
+@@ -1433,6 +1570,11 @@ HRESULT MSSTYLES_GetPropertyColor(PTHEME_PROPERTY tp, COLORREF *pColor)
+     LPCWSTR lpCur;
+     int red, green, blue;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     lpCur = tp->lpValue;
+     lpEnd = tp->lpValue + tp->dwValueLen;
+ 
+@@ -1496,6 +1638,11 @@ HRESULT MSSTYLES_GetPropertyFont(PTHEME_PROPERTY tp, HDC hdc, LOGFONTW *pFont)
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+     HRESULT hr; 
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     ZeroMemory(pFont, sizeof(LOGFONTW));
+     hr = MSSTYLES_GetFont (lpCur, lpEnd, &lpCur, pFont);
+     if (SUCCEEDED (hr))
+@@ -1511,6 +1658,11 @@ HRESULT MSSTYLES_GetPropertyFont(PTHEME_PROPERTY tp, HDC hdc, LOGFONTW *pFont)
+  */
+ HRESULT MSSTYLES_GetPropertyInt(PTHEME_PROPERTY tp, int *piVal)
+ {
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     if(!MSSTYLES_GetNextInteger(tp->lpValue, (tp->lpValue + tp->dwValueLen), NULL, piVal)) {
+         TRACE("Could not parse int property\n");
+         return E_PROP_ID_UNSUPPORTED;
+@@ -1529,6 +1681,11 @@ HRESULT MSSTYLES_GetPropertyIntList(PTHEME_PROPERTY tp, INTLIST *pIntList)
+     LPCWSTR lpCur = tp->lpValue;
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     for(i=0; i < MAX_INTLIST_COUNT; i++) {
+         if(!MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pIntList->iValues[i]))
+             break;
+@@ -1548,6 +1705,11 @@ HRESULT MSSTYLES_GetPropertyPosition(PTHEME_PROPERTY tp, POINT *pPoint)
+     LPCWSTR lpCur = tp->lpValue;
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     if(!MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &x)) {
+         TRACE("Could not parse position property\n");
+         return E_PROP_ID_UNSUPPORTED;
+@@ -1582,6 +1744,11 @@ HRESULT MSSTYLES_GetPropertyRect(PTHEME_PROPERTY tp, RECT *pRect)
+     LPCWSTR lpCur = tp->lpValue;
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pRect->left);
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pRect->top);
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pRect->right);
+@@ -1602,6 +1769,11 @@ HRESULT MSSTYLES_GetPropertyMargins(PTHEME_PROPERTY tp, RECT *prc, MARGINS *pMar
+     LPCWSTR lpCur = tp->lpValue;
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pMargins->cxLeftWidth);
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pMargins->cxRightWidth);
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pMargins->cyTopHeight);
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index cc6deea..b1a5666 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -31,6 +31,7 @@ typedef struct _THEME_PROPERTY {
+     int iPrimitiveType;
+     int iPropertyId;
+     PROPERTYORIGIN origin;
++    int version;
+ 
+     LPCWSTR lpValue;
+     DWORD dwValueLen;
+@@ -55,6 +56,7 @@ typedef struct _THEME_CLASS {
+     WCHAR szClassName[MAX_THEME_CLASS_NAME];
+     PTHEME_PARTSTATE partstate;
+     struct _THEME_CLASS *overrides;
++    int classv4;
+ 
+     struct _THEME_CLASS *next;
+ } THEME_CLASS, *PTHEME_CLASS;
+diff --git a/dlls/uxtheme/property.c b/dlls/uxtheme/property.c
+index 9dffbdd..3b59fb6 100644
+--- a/dlls/uxtheme/property.c
++++ b/dlls/uxtheme/property.c
+@@ -87,6 +87,11 @@ HRESULT WINAPI GetThemeEnumValue(HTHEME hTheme, int iPartId, int iStateId,
+     if(!(tp = MSSTYLES_FindProperty(hTheme, iPartId, iStateId, TMT_ENUM, iPropId)))
+         return E_PROP_ID_UNSUPPORTED;
+ 
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     hr = MSSTYLES_GetPropertyString(tp, val, sizeof(val)/sizeof(val[0]));
+     if(FAILED(hr))
+         return hr;
+@@ -110,6 +115,12 @@ HRESULT WINAPI GetThemeFilename(HTHEME hTheme, int iPartId, int iStateId,
+ 
+     if(!(tp = MSSTYLES_FindProperty(hTheme, iPartId, iStateId, TMT_FILENAME, iPropId)))
+         return E_PROP_ID_UNSUPPORTED;
++
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    }
++
+     return MSSTYLES_GetPropertyString(tp, pszThemeFilename, cchMaxBuffChars);
+ }
+ 
+@@ -250,28 +261,34 @@ HRESULT WINAPI GetThemeMetric(HTHEME hTheme, HDC hdc, int iPartId,
+ 
+     if(!(tp = MSSTYLES_FindProperty(hTheme, iPartId, iStateId, 0, iPropId)))
+         return E_PROP_ID_UNSUPPORTED;
+-    switch(tp->iPrimitiveType) {
+-        case TMT_POSITION: /* Only the X coord is retrieved */
+-        case TMT_MARGINS: /* Only the cxLeftWidth member is retrieved */
+-        case TMT_INTLIST: /* Only the first int is retrieved */
+-        case TMT_SIZE:
+-        case TMT_INT:
+-            return MSSTYLES_GetPropertyInt(tp, piVal);
+-        case TMT_BOOL:
+-            return MSSTYLES_GetPropertyBool(tp, piVal);
+-        case TMT_COLOR:
+-            return MSSTYLES_GetPropertyColor(tp, (COLORREF*)piVal);
+-        case TMT_ENUM:
+-            hr = MSSTYLES_GetPropertyString(tp, val, sizeof(val)/sizeof(val[0]));
+-            if(FAILED(hr))
+-                return hr;
+-            if(!MSSTYLES_LookupEnum(val, iPropId, piVal))
+-                return E_PROP_ID_UNSUPPORTED;
+-            return S_OK;
+-         case TMT_FILENAME:
+-             /* Windows does return a value for this, but its value doesn't make sense */
+-             FIXME("Filename\n");
+-             break;
++
++    if (tp->version == 4) {
++        FIXME("Not yet supported for v4 themes\n");
++        return E_NOTIMPL;
++    } else {
++        switch(tp->iPrimitiveType) {
++            case TMT_POSITION: /* Only the X coord is retrieved */
++            case TMT_MARGINS: /* Only the cxLeftWidth member is retrieved */
++            case TMT_INTLIST: /* Only the first int is retrieved */
++            case TMT_SIZE:
++            case TMT_INT:
++                return MSSTYLES_GetPropertyInt(tp, piVal);
++            case TMT_BOOL:
++                return MSSTYLES_GetPropertyBool(tp, piVal);
++            case TMT_COLOR:
++                return MSSTYLES_GetPropertyColor(tp, (COLORREF*)piVal);
++            case TMT_ENUM:
++                hr = MSSTYLES_GetPropertyString(tp, val, sizeof(val)/sizeof(val[0]));
++                if(FAILED(hr))
++                    return hr;
++                if(!MSSTYLES_LookupEnum(val, iPropId, piVal))
++                    return E_PROP_ID_UNSUPPORTED;
++                return S_OK;
++            case TMT_FILENAME:
++                /* Windows does return a value for this, but its value doesn't make sense */
++                FIXME("Filename\n");
++                break;
++        }
+     }
+     return E_PROP_ID_UNSUPPORTED;
+ }
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0006-uxtheme-Implement-GetThemeDocumentationProperty-for-.patch
+++ b/patches/uxtheme-MSStylesV4/0006-uxtheme-Implement-GetThemeDocumentationProperty-for-.patch
@@ -1,0 +1,147 @@
+From ba7d60033f0c6778dce3b30375dbfbcf522dc035 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 21:55:28 +0100
+Subject: [PATCH 06/19] uxtheme: Implement GetThemeDocumentationProperty for v4
+ themes.
+
+---
+ dlls/uxtheme/msstyles.c |  2 +-
+ dlls/uxtheme/msstyles.h |  3 +++
+ dlls/uxtheme/system.c   | 67 ++++++++++++++++++++++++++++++++++---------------
+ 3 files changed, 51 insertions(+), 21 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index a65e94f..bad9682 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -586,7 +586,7 @@ static BOOL MSSTYLES_ParseIniSectionName(LPCWSTR lpSection, DWORD dwLen, LPWSTR
+  * RETURNS
+  *  The class found, or NULL
+  */
+-static PTHEME_CLASS MSSTYLES_FindClass(PTHEME_FILE tf, LPCWSTR pszAppName, LPCWSTR pszClassName)
++PTHEME_CLASS MSSTYLES_FindClass(PTHEME_FILE tf, LPCWSTR pszAppName, LPCWSTR pszClassName)
+ {
+     PTHEME_CLASS cur = tf->classes;
+     while(cur) {
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index b1a5666..6bf7454 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -121,6 +121,9 @@ HRESULT MSSTYLES_GetPropertyPosition(PTHEME_PROPERTY tp, POINT *pPoint) DECLSPEC
+ HRESULT MSSTYLES_GetPropertyString(PTHEME_PROPERTY tp, LPWSTR pszBuff, int cchMaxBuffChars) DECLSPEC_HIDDEN;
+ HRESULT MSSTYLES_GetPropertyRect(PTHEME_PROPERTY tp, RECT *pRect) DECLSPEC_HIDDEN;
+ HRESULT MSSTYLES_GetPropertyMargins(PTHEME_PROPERTY tp, RECT *prc, MARGINS *pMargins) DECLSPEC_HIDDEN;
++void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name) DECLSPEC_HIDDEN;
++void MSSTYLES_ParseV4ClassMap(PTHEME_FILE tf) DECLSPEC_HIDDEN;
++PTHEME_CLASS MSSTYLES_FindClass(PTHEME_FILE tf, LPCWSTR pszAppName, LPCWSTR pszClassName) DECLSPEC_HIDDEN;
+ 
+ PUXINI_FILE UXINI_LoadINI(HMODULE hTheme, LPCWSTR lpName) DECLSPEC_HIDDEN;
+ void UXINI_CloseINI(PUXINI_FILE uf) DECLSPEC_HIDDEN;
+diff --git a/dlls/uxtheme/system.c b/dlls/uxtheme/system.c
+index 8947587..6ded6b3 100644
+--- a/dlls/uxtheme/system.c
++++ b/dlls/uxtheme/system.c
+@@ -30,12 +30,13 @@
+ #include "winreg.h"
+ #include "vfwmsgs.h"
+ #include "uxtheme.h"
+-#include "tmschema.h"
++#include "vssym32.h"
+ 
+ #include "uxthemedll.h"
+ #include "msstyles.h"
+ 
+ #include "wine/debug.h"
++#include "wine/unicode.h"
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(uxtheme);
+ 
+@@ -802,40 +803,66 @@ HRESULT WINAPI GetThemeDocumentationProperty(LPCWSTR pszThemeName,
+         TMT_DESCRIPTION,5007
+     };
+ 
++    const WCHAR documentationW[] = { 'd','o','c','u','m','e','n','t','a','t','i','o','n',0 };
++
+     PTHEME_FILE pt;
++    PTHEME_CLASS ptc;
+     HRESULT hr;
+     unsigned int i;
+     int iDocId;
++
+     TRACE("(%s,%s,%p,%d)\n", debugstr_w(pszThemeName), debugstr_w(pszPropertyName),
+           pszValueBuff, cchMaxValChars);
+ 
+     hr = MSSTYLES_OpenThemeFile(pszThemeName, NULL, NULL, &pt);
+     if(FAILED(hr)) return hr;
+ 
+-    /* Try to load from string resources */
+-    hr = E_PROP_ID_UNSUPPORTED;
+-    if(MSSTYLES_LookupProperty(pszPropertyName, NULL, &iDocId)) {
+-        for(i=0; i<sizeof(wDocToRes)/sizeof(wDocToRes[0]); i+=2) {
+-            if(wDocToRes[i] == iDocId) {
+-                if(LoadStringW(pt->hTheme, wDocToRes[i+1], pszValueBuff, cchMaxValChars)) {
+-                    hr = S_OK;
+-                    break;
++    if (pt->version == 4) {
++        if (!strcmpiW(pszPropertyName, SZ_THDOCPROP_DISPLAYNAME))
++            iDocId = TMT_DISPLAYNAME;
++        else if (!strcmpiW(pszPropertyName, SZ_THDOCPROP_CANONICALNAME))
++            iDocId = TMT_NAME;
++        else if (!strcmpiW(pszPropertyName, SZ_THDOCPROP_TOOLTIP))
++            iDocId = TMT_TOOLTIP;
++        else if (!strcmpiW(pszPropertyName, SZ_THDOCPROP_AUTHOR))
++            iDocId = TMT_AUTHOR;
++        else {
++            MSSTYLES_CloseThemeFile(pt);
++            return E_PROP_ID_UNSUPPORTED;
++        }
++
++        MSSTYLES_ParseV4ClassMap(pt);
++        MSSTYLES_ParseV4Properties(pt, NULL);
++
++        ptc = MSSTYLES_FindClass(pt, NULL, documentationW);
++
++        hr = GetThemeString(ptc, 0, 0, iDocId, pszValueBuff, cchMaxValChars);
++    } else {
++        /* Try to load from string resources */
++        hr = E_PROP_ID_UNSUPPORTED;
++        if(MSSTYLES_LookupProperty(pszPropertyName, NULL, &iDocId)) {
++            for(i=0; i<sizeof(wDocToRes)/sizeof(wDocToRes[0]); i+=2) {
++                if(wDocToRes[i] == iDocId) {
++                    if(LoadStringW(pt->hTheme, wDocToRes[i+1], pszValueBuff, cchMaxValChars)) {
++                        hr = S_OK;
++                        break;
++                    }
+                 }
+             }
+         }
+-    }
+-    /* If loading from string resource failed, try getting it from the theme.ini */
+-    if(FAILED(hr)) {
+-        PUXINI_FILE uf = MSSTYLES_GetThemeIni(pt);
+-        if(UXINI_FindSection(uf, szIniDocumentation)) {
+-            LPCWSTR lpValue;
+-            DWORD dwLen;
+-            if(UXINI_FindValue(uf, pszPropertyName, &lpValue, &dwLen)) {
+-                lstrcpynW(pszValueBuff, lpValue, min(dwLen+1,cchMaxValChars));
+-                hr = S_OK;
++        /* If loading from string resource failed, try getting it from the theme.ini */
++        if(FAILED(hr)) {
++            PUXINI_FILE uf = MSSTYLES_GetThemeIni(pt);
++            if(UXINI_FindSection(uf, szIniDocumentation)) {
++                LPCWSTR lpValue;
++                DWORD dwLen;
++                if(UXINI_FindValue(uf, pszPropertyName, &lpValue, &dwLen)) {
++                    lstrcpynW(pszValueBuff, lpValue, min(dwLen+1,cchMaxValChars));
++                    hr = S_OK;
++                }
+             }
++            UXINI_CloseINI(uf);
+         }
+-        UXINI_CloseINI(uf);
+     }
+ 
+     MSSTYLES_CloseThemeFile(pt);
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0007-uxtheme-Implement-v4-EnumThemeColors-and-EnumThemeSi.patch
+++ b/patches/uxtheme-MSStylesV4/0007-uxtheme-Implement-v4-EnumThemeColors-and-EnumThemeSi.patch
@@ -1,0 +1,145 @@
+From 607f8141080fd5e5d81e5aca01b9f1dc3e699510 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 22:02:59 +0100
+Subject: [PATCH 07/19] uxtheme: Implement v4 EnumThemeColors and
+ EnumThemeSizes.
+
+---
+ dlls/uxtheme/system.c | 92 +++++++++++++++++++++++++++++++++++++++++----------
+ 1 file changed, 75 insertions(+), 17 deletions(-)
+
+diff --git a/dlls/uxtheme/system.c b/dlls/uxtheme/system.c
+index 6ded6b3..33d9a04 100644
+--- a/dlls/uxtheme/system.c
++++ b/dlls/uxtheme/system.c
+@@ -1104,6 +1104,9 @@ HRESULT WINAPI EnumThemeColors(LPWSTR pszThemeFileName, LPWSTR pszSizeName,
+     HRESULT hr;
+     LPWSTR tmp;
+     UINT resourceId = dwColorNum + 1000;
++
++    static const WCHAR prefixW[] = {'c','o','l','o','r','v','a','r','i','a','n','t','.',0};
++
+     TRACE("(%s,%s,%d)\n", debugstr_w(pszThemeFileName),
+           debugstr_w(pszSizeName), dwColorNum);
+ 
+@@ -1117,13 +1120,39 @@ HRESULT WINAPI EnumThemeColors(LPWSTR pszThemeFileName, LPWSTR pszSizeName,
+     }
+     if(!dwColorNum && *tmp) {
+         TRACE("%s\n", debugstr_w(tmp));
+-        lstrcpyW(pszColorNames->szName, tmp);
+-        LoadStringW (pt->hTheme, resourceId,
+-            pszColorNames->szDisplayName,
+-            sizeof (pszColorNames->szDisplayName) / sizeof (WCHAR));
+-        LoadStringW (pt->hTheme, resourceId+1000,
+-            pszColorNames->szTooltip,
+-            sizeof (pszColorNames->szTooltip) / sizeof (WCHAR));
++        if (pt->version == 4) {
++            WCHAR classname[1024];
++            PTHEME_CLASS ptc;
++
++            MSSTYLES_ParseV4ClassMap(pt);
++            MSSTYLES_ParseV4Properties(pt, NULL);
++
++            strcpyW(classname, prefixW);
++            strcatW(classname, tmp);
++            ptc = MSSTYLES_FindClass(pt, NULL, classname);
++
++            lstrcpyW(pszColorNames->szName, tmp);
++            if (ptc) {
++                if (FAILED(GetThemeString(ptc, 0, 0, TMT_DISPLAYNAME, pszColorNames->szDisplayName,
++                sizeof (pszColorNames->szDisplayName) / sizeof (WCHAR))))
++                    strcpyW(pszColorNames->szDisplayName, tmp);
++
++                if (FAILED(GetThemeString(ptc, 0, 0, TMT_TOOLTIP, pszColorNames->szTooltip,
++                sizeof (pszColorNames->szTooltip) / sizeof (WCHAR))))
++                    pszColorNames->szTooltip[0] = 0;
++            } else {
++                strcpyW(pszColorNames->szDisplayName, tmp);
++                pszColorNames->szTooltip[0] = 0;
++            }
++        } else {
++            lstrcpyW(pszColorNames->szName, tmp);
++            LoadStringW (pt->hTheme, resourceId,
++                pszColorNames->szDisplayName,
++                sizeof (pszColorNames->szDisplayName) / sizeof (WCHAR));
++            LoadStringW (pt->hTheme, resourceId+1000,
++                pszColorNames->szTooltip,
++                sizeof (pszColorNames->szTooltip) / sizeof (WCHAR));
++        }
+     }
+     else
+         hr = E_PROP_ID_UNSUPPORTED;
+@@ -1157,17 +1186,20 @@ HRESULT WINAPI EnumThemeColors(LPWSTR pszThemeFileName, LPWSTR pszSizeName,
+  * this is undocumented and almost never called..
+  * (and this is how windows works too)
+  */
+-HRESULT WINAPI EnumThemeSizes(LPWSTR pszThemeFileName, LPWSTR pszColorName,
++HRESULT WINAPI EnumThemeSizes(LPWSTR pszThemeFileName, LPWSTR pszSizeName,
+                               DWORD dwSizeNum, PTHEMENAMES pszSizeNames)
+ {
+     PTHEME_FILE pt;
+     HRESULT hr;
+     LPWSTR tmp;
+     UINT resourceId = dwSizeNum + 3000;
++
++    static const WCHAR prefixW[] = {'s','i','z','e','v','a','r','i','a','n','t','.',0};
++
+     TRACE("(%s,%s,%d)\n", debugstr_w(pszThemeFileName),
+-          debugstr_w(pszColorName), dwSizeNum);
++          debugstr_w(pszSizeName), dwSizeNum);
+ 
+-    hr = MSSTYLES_OpenThemeFile(pszThemeFileName, pszColorName, NULL, &pt);
++    hr = MSSTYLES_OpenThemeFile(pszThemeFileName, pszSizeName, NULL, &pt);
+     if(FAILED(hr)) return hr;
+ 
+     tmp = pt->pszAvailSizes;
+@@ -1177,13 +1209,39 @@ HRESULT WINAPI EnumThemeSizes(LPWSTR pszThemeFileName, LPWSTR pszColorName,
+     }
+     if(!dwSizeNum && *tmp) {
+         TRACE("%s\n", debugstr_w(tmp));
+-        lstrcpyW(pszSizeNames->szName, tmp);
+-        LoadStringW (pt->hTheme, resourceId,
+-            pszSizeNames->szDisplayName,
+-            sizeof (pszSizeNames->szDisplayName) / sizeof (WCHAR));
+-        LoadStringW (pt->hTheme, resourceId+1000,
+-            pszSizeNames->szTooltip,
+-            sizeof (pszSizeNames->szTooltip) / sizeof (WCHAR));
++        if (pt->version == 4) {
++            WCHAR classname[1024];
++            PTHEME_CLASS ptc;
++
++            MSSTYLES_ParseV4ClassMap(pt);
++            MSSTYLES_ParseV4Properties(pt, NULL);
++
++            strcpyW(classname, prefixW);
++            strcatW(classname, tmp);
++            ptc = MSSTYLES_FindClass(pt, NULL, classname);
++
++            lstrcpyW(pszSizeNames->szName, tmp);
++            if (ptc) {
++                if (FAILED(GetThemeString(ptc, 0, 0, TMT_DISPLAYNAME, pszSizeNames->szDisplayName,
++                sizeof (pszSizeNames->szDisplayName) / sizeof (WCHAR))))
++                    strcpyW(pszSizeNames->szDisplayName, tmp);
++
++                if (FAILED(GetThemeString(ptc, 0, 0, TMT_TOOLTIP, pszSizeNames->szTooltip,
++                sizeof (pszSizeNames->szTooltip) / sizeof (WCHAR))))
++                    pszSizeNames->szTooltip[0] = 0;
++            } else {
++                strcpyW(pszSizeNames->szDisplayName, tmp);
++                pszSizeNames->szTooltip[0] = 0;
++            }
++        } else {
++            lstrcpyW(pszSizeNames->szName, tmp);
++            LoadStringW (pt->hTheme, resourceId,
++                pszSizeNames->szDisplayName,
++                sizeof (pszSizeNames->szDisplayName) / sizeof (WCHAR));
++            LoadStringW (pt->hTheme, resourceId+1000,
++                pszSizeNames->szTooltip,
++                sizeof (pszSizeNames->szTooltip) / sizeof (WCHAR));
++        }
+     }
+     else
+         hr = E_PROP_ID_UNSUPPORTED;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0008-uxtheme-Parse-v4-integer-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0008-uxtheme-Parse-v4-integer-properties.patch
@@ -1,0 +1,100 @@
+From f53c24d8146d12741668b9ee484984d494e01555 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 22:11:44 +0100
+Subject: [PATCH 08/19] uxtheme: Parse v4 integer properties.
+
+---
+ dlls/uxtheme/msstyles.c | 23 +++++++++++++++++++----
+ dlls/uxtheme/msstyles.h |  4 ++++
+ dlls/uxtheme/property.c |  4 ++--
+ 3 files changed, 25 insertions(+), 6 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index bad9682..4d23a02 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -972,6 +972,12 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+ 
+         if (ph->resref == 0) {
+             switch (ph->type) {
++                case TMT_ENUM:
++                case TMT_INT:
++                case TMT_BOOL:
++                    memcpy(&prop->u.integer, &buf[i], min(sizeof(signed long), ph->datalen));
++                break;
++
+                 case TMT_STRING:
+                     prop->lpValue = (LPCWSTR)&buf[i];
+                     prop->dwValueLen = ph->datalen / sizeof(WCHAR);
+@@ -983,7 +989,16 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+             }
+             i += ph->datalen;
+         } else {
++            WCHAR s[1024];
++
+             switch (ph->type) {
++                case TMT_ENUM:
++                case TMT_INT:
++                case TMT_BOOL:
++                    LoadStringW(tf->hMUIFile, ph->resref, s, sizeof(s)/sizeof(*s));
++                    prop->u.integer = atoiW(s);
++                break;
++
+                 case TMT_STRING:
+                     LoadStringW(tf->hMUIFile, ph->resref, (LPWSTR)&prop->lpValue, 0);
+                     prop->dwValueLen = (ph->datalen - 1) / sizeof(WCHAR);
+@@ -1549,8 +1564,8 @@ static BOOL MSSTYLES_GetNextToken(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LP
+ HRESULT MSSTYLES_GetPropertyBool(PTHEME_PROPERTY tp, BOOL *pfVal)
+ {
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        *pfVal = tp->u.integer ? TRUE : FALSE;
++        return S_OK;
+     }
+ 
+     *pfVal = FALSE;
+@@ -1659,8 +1674,8 @@ HRESULT MSSTYLES_GetPropertyFont(PTHEME_PROPERTY tp, HDC hdc, LOGFONTW *pFont)
+ HRESULT MSSTYLES_GetPropertyInt(PTHEME_PROPERTY tp, int *piVal)
+ {
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        *piVal = tp->u.integer;
++        return S_OK;
+     }
+ 
+     if(!MSSTYLES_GetNextInteger(tp->lpValue, (tp->lpValue + tp->dwValueLen), NULL, piVal)) {
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 6bf7454..8faa7ce 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -36,6 +36,10 @@ typedef struct _THEME_PROPERTY {
+     LPCWSTR lpValue;
+     DWORD dwValueLen;
+ 
++    union {
++        signed long integer;
++    } u;
++
+     struct _THEME_PROPERTY *next;
+ } THEME_PROPERTY, *PTHEME_PROPERTY;
+ 
+diff --git a/dlls/uxtheme/property.c b/dlls/uxtheme/property.c
+index 3b59fb6..aace3d5 100644
+--- a/dlls/uxtheme/property.c
++++ b/dlls/uxtheme/property.c
+@@ -88,8 +88,8 @@ HRESULT WINAPI GetThemeEnumValue(HTHEME hTheme, int iPartId, int iStateId,
+         return E_PROP_ID_UNSUPPORTED;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        *piVal = tp->u.integer;
++        return S_OK;
+     }
+ 
+     hr = MSSTYLES_GetPropertyString(tp, val, sizeof(val)/sizeof(val[0]));
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0009-uxtheme-Draw-v4-images.patch
+++ b/patches/uxtheme-MSStylesV4/0009-uxtheme-Draw-v4-images.patch
@@ -1,0 +1,317 @@
+From 1787ac687ed9d04e9607aa1fd5c6dd37fe71d72f Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 22:35:55 +0100
+Subject: [PATCH 09/19] uxtheme: Draw v4 images.
+
+---
+ dlls/uxtheme/Makefile.in |   2 +-
+ dlls/uxtheme/draw.c      |  30 +++++---
+ dlls/uxtheme/msstyles.c  | 178 ++++++++++++++++++++++++++++++++++++++++++++++-
+ dlls/uxtheme/msstyles.h  |   2 +
+ 4 files changed, 202 insertions(+), 10 deletions(-)
+
+diff --git a/dlls/uxtheme/Makefile.in b/dlls/uxtheme/Makefile.in
+index c3fff30..3d2a0c0 100644
+--- a/dlls/uxtheme/Makefile.in
++++ b/dlls/uxtheme/Makefile.in
+@@ -1,6 +1,6 @@
+ MODULE    = uxtheme.dll
+ IMPORTLIB = uxtheme
+-IMPORTS   = user32 gdi32 advapi32
++IMPORTS   = user32 gdi32 advapi32 ole32 windowscodecs
+ DELAYIMPORTS = msimg32
+ 
+ C_SRCS = \
+diff --git a/dlls/uxtheme/draw.c b/dlls/uxtheme/draw.c
+index 8a9397d..aa9f339 100644
+--- a/dlls/uxtheme/draw.c
++++ b/dlls/uxtheme/draw.c
+@@ -198,9 +198,13 @@ static PTHEME_PROPERTY UXTHEME_SelectImage(HTHEME hTheme, HDC hdc, int iPartId,
+                 HBITMAP hBmp;
+                 BOOL hasAlpha;
+ 
+-                lstrcpynW(szPath, fileProp->lpValue, 
+-                    min(fileProp->dwValueLen+1, sizeof(szPath)/sizeof(szPath[0])));
+-                hBmp = MSSTYLES_LoadBitmap(hTheme, szPath, &hasAlpha);
++                if (fileProp->lpValue) {
++                    lstrcpynW(szPath, fileProp->lpValue,
++                        min(fileProp->dwValueLen+1, sizeof(szPath)/sizeof(szPath[0])));
++                    hBmp = MSSTYLES_LoadBitmap(hTheme, szPath, &hasAlpha);
++                } else {
++                    hBmp = MSSTYLES_LoadBitmapInt(hTheme, fileProp->u.integer, &hasAlpha);
++                }
+                 if(!hBmp) continue;
+ 
+                 GetThemeEnumValue(hTheme, iPartId, iStateId, TMT_IMAGELAYOUT, &imagelayout);
+@@ -240,16 +244,26 @@ static HRESULT UXTHEME_LoadImage(HTHEME hTheme, HDC hdc, int iPartId, int iState
+     int imagenum;
+     BITMAP bmp;
+     WCHAR szPath[MAX_PATH];
++
+     PTHEME_PROPERTY tp = UXTHEME_SelectImage(hTheme, hdc, iPartId, iStateId, pRect, glyph);
+     if(!tp) {
+         FIXME("Couldn't determine image for part/state %d/%d, invalid theme?\n", iPartId, iStateId);
+         return E_PROP_ID_UNSUPPORTED;
+     }
+-    lstrcpynW(szPath, tp->lpValue, min(tp->dwValueLen+1, sizeof(szPath)/sizeof(szPath[0])));
+-    *hBmp = MSSTYLES_LoadBitmap(hTheme, szPath, hasImageAlpha);
+-    if(!*hBmp) {
+-        TRACE("Failed to load bitmap %s\n", debugstr_w(szPath));
+-        return HRESULT_FROM_WIN32(GetLastError());
++
++    if (!tp->lpValue) { /* v4 property using integer resource reference */
++        *hBmp = MSSTYLES_LoadBitmapInt(hTheme, tp->u.integer, hasImageAlpha);
++        if(!*hBmp) {
++            TRACE("Failed to load bitmap %li\n", tp->u.integer);
++            return HRESULT_FROM_WIN32(GetLastError());
++        }
++    } else {
++        lstrcpynW(szPath, tp->lpValue, min(tp->dwValueLen+1, sizeof(szPath)/sizeof(szPath[0])));
++        *hBmp = MSSTYLES_LoadBitmap(hTheme, szPath, hasImageAlpha);
++        if(!*hBmp) {
++            TRACE("Failed to load bitmap %s\n", debugstr_w(szPath));
++            return HRESULT_FROM_WIN32(GetLastError());
++        }
+     }
+     
+     GetThemeEnumValue(hTheme, iPartId, iStateId, TMT_IMAGELAYOUT, &imagelayout);
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 4d23a02..0c11a83 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -20,6 +20,8 @@
+ 
+ #include "config.h"
+ 
++#define COBJMACROS
++
+ #include <stdarg.h>
+ #include <stdlib.h>
+ 
+@@ -30,7 +32,10 @@
+ #include "winnls.h"
+ #include "vfwmsgs.h"
+ #include "uxtheme.h"
+-#include "tmschema.h"
++#include "vssym32.h"
++
++#include "initguid.h"
++#include "wincodec.h"
+ 
+ #include "msstyles.h"
+ 
+@@ -1004,6 +1009,11 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     prop->dwValueLen = (ph->datalen - 1) / sizeof(WCHAR);
+                 break;
+ 
++                case TMT_FILENAME:
++                case TMT_DISKSTREAM:
++                    prop->u.integer = ph->resref;
++                break;
++
+                 default:
+                     FIXME("Unprocessed resource property type %u\n", ph->type);
+                 break;
+@@ -1504,6 +1514,7 @@ HBITMAP MSSTYLES_LoadBitmap (PTHEME_CLASS tc, LPCWSTR lpFilename, BOOL* hasAlpha
+     img->image = LoadImageW(tc->hTheme, szFile, IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION);
+     prepare_alpha (img->image, hasAlpha);
+     img->hasAlpha = *hasAlpha;
++    img->resref = -1;
+     /* ...and stow away for later reuse. */
+     lstrcpyW (img->name, szFile);
+     img->next = tc->tf->images;
+@@ -1512,6 +1523,171 @@ HBITMAP MSSTYLES_LoadBitmap (PTHEME_CLASS tc, LPCWSTR lpFilename, BOOL* hasAlpha
+     return img->image;
+ }
+ 
++static HBITMAP PNGtoBitmap(BYTE* buf, DWORD size)
++{
++    HGLOBAL hmem;
++    BYTE* data;
++    IStream* stream;
++    IWICImagingFactory* factory;
++    IWICBitmapDecoder* decoder;
++    IWICBitmapFrameDecode* frame;
++    IWICBitmapSource* bitmap;
++    unsigned int width, height;
++    BITMAPINFO bmpinfo;
++    HDC dc;
++    void* bmpdata;
++    HBITMAP hbitmap = NULL;
++
++    hmem = GlobalAlloc(0, size);
++    data = GlobalLock(hmem);
++    memcpy(data, buf, size);
++    GlobalUnlock(hmem);
++
++    if (FAILED(CreateStreamOnHGlobal(hmem, TRUE, &stream))) {
++        WARN("CreateStreamOnHGlobal failed\n");
++        return NULL;
++    }
++
++    CoInitialize(NULL);
++
++    if (FAILED(CoCreateInstance(&CLSID_WICImagingFactory, NULL, CLSCTX_INPROC_SERVER,
++                          &IID_IWICImagingFactory, (void **)&factory)))
++    {
++        WARN("CoCreateInstance failed\n");
++        IStream_Release(stream);
++        CoUninitialize();
++        return NULL;
++    }
++
++    if (FAILED(IWICImagingFactory_CreateDecoderFromStream(factory, stream, NULL, 0, &decoder)))
++    {
++        WARN("IWICImagingFactory_CreateDecoderFromStream failed\n");
++        IWICImagingFactory_Release(factory);
++        IStream_Release(stream);
++        CoUninitialize();
++        return NULL;
++    }
++
++    if (FAILED(IWICBitmapDecoder_GetFrame(decoder, 0, &frame)))
++    {
++        WARN("IWICBitmapDecoder_GetFrame failed\n");
++        IWICBitmapDecoder_Release(decoder);
++        IWICImagingFactory_Release(factory);
++        IStream_Release(stream);
++        CoUninitialize();
++        return NULL;
++    }
++
++    if (FAILED(WICConvertBitmapSource(&GUID_WICPixelFormat32bppBGRA, (IWICBitmapSource*)frame, &bitmap)))
++    {
++        WARN("WICConvertBitmapSource failed\n");
++        IWICBitmapFrameDecode_Release(frame);
++        IWICBitmapDecoder_Release(decoder);
++        IWICImagingFactory_Release(factory);
++        IStream_Release(stream);
++        CoUninitialize();
++        return NULL;
++    }
++
++    IWICBitmapFrameDecode_Release(frame);
++
++    if (FAILED(IWICBitmapSource_GetSize(bitmap, &width, &height)))
++    {
++        WARN("IWICBitmapSource_GetSize failed\n");
++        goto end;
++    }
++
++    bmpinfo.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
++    bmpinfo.bmiHeader.biWidth = width;
++    bmpinfo.bmiHeader.biHeight = -height;
++    bmpinfo.bmiHeader.biPlanes = 1;
++    bmpinfo.bmiHeader.biBitCount = 32;
++    bmpinfo.bmiHeader.biCompression = BI_RGB;
++
++    dc = GetDC(NULL);
++    hbitmap = CreateDIBSection(dc, &bmpinfo, DIB_RGB_COLORS, &bmpdata, NULL, 0);
++    ReleaseDC(NULL, dc);
++    if (!hbitmap)
++    {
++        WARN("CreateDIBSection failed\n");
++        goto end;
++    }
++
++    if (FAILED(IWICBitmapSource_CopyPixels(bitmap, NULL, width*4, width*height*4, bmpdata)))
++    {
++        WARN("IWICBitmapSource_CopyPixels failed\n");
++        DeleteObject(hbitmap); hbitmap = NULL;
++        goto end;
++    }
++
++end:
++    IWICBitmapSource_Release(bitmap);
++    IWICBitmapDecoder_Release(decoder);
++    IWICImagingFactory_Release(factory);
++    IStream_Release(stream);
++    CoUninitialize();
++
++    return hbitmap;
++}
++
++HBITMAP MSSTYLES_LoadBitmapInt(PTHEME_CLASS tc, int resref, BOOL* hasAlpha)
++{
++    PTHEME_IMAGE img;
++    DWORD size;
++    HRSRC hrsc;
++    BYTE* buf;
++    HBITMAP bmp;
++
++    static const WCHAR imageW[] = {'I','M','A','G','E',0};
++
++    img = tc->tf->images;
++    while (img)
++    {
++        if (img->resref == resref)
++        {
++            TRACE ("found %p %u: %p\n", img, resref, img->image);
++            *hasAlpha = img->hasAlpha;
++            return img->image;
++        }
++        img = img->next;
++    }
++
++    if (!(hrsc = FindResourceW(tc->tf->hTheme, MAKEINTRESOURCEW(resref), imageW))) {
++        WARN("No image resource found\n");
++        return NULL;
++    }
++
++    size = SizeofResource(tc->tf->hTheme, hrsc);
++
++    buf = (BYTE*)LoadResource(tc->tf->hTheme, hrsc);
++    if (!buf) {
++        WARN("Could not open image resource\n");
++        return NULL;
++    }
++
++    bmp = PNGtoBitmap(buf, size);
++    if (!bmp) {
++        WARN("Error reading image file\n");
++        return NULL;
++    }
++
++    img = HeapAlloc(GetProcessHeap(), 0, sizeof (THEME_IMAGE));
++
++    img->name[0] = 0;
++    img->resref = resref;
++    img->hasAlpha = TRUE;
++    img->image = bmp;
++
++    img->next = tc->tf->images;
++    tc->tf->images = img;
++
++    *hasAlpha = img->hasAlpha;
++
++    TRACE ("new %p %u: %p\n", img, resref, img->image);
++
++    return img->image;
++}
++
+ static BOOL MSSTYLES_GetNextInteger(LPCWSTR lpStringStart, LPCWSTR lpStringEnd, LPCWSTR *lpValEnd, int *value)
+ {
+     LPCWSTR cur = lpStringStart;
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 8faa7ce..f512073 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -67,6 +67,7 @@ typedef struct _THEME_CLASS {
+ 
+ typedef struct _THEME_IMAGE {
+     WCHAR name[MAX_PATH];
++    int resref;
+     HBITMAP image;
+     BOOL hasAlpha;
+     
+@@ -115,6 +116,7 @@ PTHEME_PARTSTATE MSSTYLES_FindPartState(PTHEME_CLASS tc, int iPartId, int iState
+ PTHEME_PROPERTY MSSTYLES_FindProperty(PTHEME_CLASS tc, int iPartId, int iStateId, int iPropertyPrimitive, int iPropertyId) DECLSPEC_HIDDEN;
+ PTHEME_PROPERTY MSSTYLES_FindMetric(int iPropertyPrimitive, int iPropertyId) DECLSPEC_HIDDEN;
+ HBITMAP MSSTYLES_LoadBitmap(PTHEME_CLASS tc, LPCWSTR lpFilename, BOOL* hasAlpha) DECLSPEC_HIDDEN;
++HBITMAP MSSTYLES_LoadBitmapInt(PTHEME_CLASS tc, int resref, BOOL* hasAlpha) DECLSPEC_HIDDEN;
+ 
+ HRESULT MSSTYLES_GetPropertyBool(PTHEME_PROPERTY tp, BOOL *pfVal) DECLSPEC_HIDDEN;
+ HRESULT MSSTYLES_GetPropertyColor(PTHEME_PROPERTY tp, COLORREF *pColor) DECLSPEC_HIDDEN;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0010-uxtheme-Parse-v4-colour-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0010-uxtheme-Parse-v4-colour-properties.patch
@@ -1,0 +1,51 @@
+From 79e1d945214185c33159ee6690c749b94ca116d5 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 22:49:25 +0100
+Subject: [PATCH 10/19] uxtheme: Parse v4 colour properties.
+
+---
+ dlls/uxtheme/msstyles.c | 8 ++++++--
+ dlls/uxtheme/msstyles.h | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 0c11a83..1907b89 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -988,6 +988,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     prop->dwValueLen = ph->datalen / sizeof(WCHAR);
+                 break;
+ 
++                case TMT_COLOR:
++                    memcpy(&prop->u.colour, &buf[i], min(sizeof(COLORREF), ph->datalen));
++                break;
++
+                 default:
+                     FIXME("Unprocessed non-resource property type %u\n", ph->type);
+                 break;
+@@ -1762,8 +1766,8 @@ HRESULT MSSTYLES_GetPropertyColor(PTHEME_PROPERTY tp, COLORREF *pColor)
+     int red, green, blue;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        *pColor = tp->u.colour;
++        return S_OK;
+     }
+ 
+     lpCur = tp->lpValue;
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index f512073..2b86be4 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -38,6 +38,7 @@ typedef struct _THEME_PROPERTY {
+ 
+     union {
+         signed long integer;
++        COLORREF colour;
+     } u;
+ 
+     struct _THEME_PROPERTY *next;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0011-uxtheme-Parse-v4-margins-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0011-uxtheme-Parse-v4-margins-properties.patch
@@ -1,0 +1,51 @@
+From 82489a17d227d2c68f909fc974231fcde6a9f46c Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 22:53:53 +0100
+Subject: [PATCH 11/19] uxtheme: Parse v4 margins properties.
+
+---
+ dlls/uxtheme/msstyles.c | 8 ++++++--
+ dlls/uxtheme/msstyles.h | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 1907b89..f4b7568 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -992,6 +992,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     memcpy(&prop->u.colour, &buf[i], min(sizeof(COLORREF), ph->datalen));
+                 break;
+ 
++                case TMT_MARGINS:
++                    memcpy(&prop->u.margins, &buf[i], min(sizeof(MARGINS), ph->datalen));
++                break;
++
+                 default:
+                     FIXME("Unprocessed non-resource property type %u\n", ph->type);
+                 break;
+@@ -1965,8 +1969,8 @@ HRESULT MSSTYLES_GetPropertyMargins(PTHEME_PROPERTY tp, RECT *prc, MARGINS *pMar
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        memcpy(pMargins, &tp->u.margins, sizeof(MARGINS));
++        return S_OK;
+     }
+ 
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pMargins->cxLeftWidth);
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 2b86be4..822aae8 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -39,6 +39,7 @@ typedef struct _THEME_PROPERTY {
+     union {
+         signed long integer;
+         COLORREF colour;
++        MARGINS margins;
+     } u;
+ 
+     struct _THEME_PROPERTY *next;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0012-uxtheme-Parse-v4-inheritance-map.patch
+++ b/patches/uxtheme-MSStylesV4/0012-uxtheme-Parse-v4-inheritance-map.patch
@@ -1,0 +1,143 @@
+From 196445e2f18e113bb7476d7616eec476047cd054 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:05:23 +0100
+Subject: [PATCH 12/19] uxtheme: Parse v4 inheritance map.
+
+---
+ dlls/uxtheme/msstyles.c | 75 +++++++++++++++++++++++++++++++++++++++++++++++--
+ dlls/uxtheme/msstyles.h |  1 +
+ 2 files changed, 74 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index f4b7568..b672adc 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -633,6 +633,7 @@ static PTHEME_CLASS MSSTYLES_AddClass(PTHEME_FILE tf, LPCWSTR pszAppName, LPCWST
+     cur->next = tf->classes;
+     cur->partstate = NULL;
+     cur->overrides = NULL;
++    cur->parent = NULL;
+     tf->classes = cur;
+     return cur;
+ }
+@@ -902,6 +903,63 @@ void MSSTYLES_ParseV4ClassMap(PTHEME_FILE tf)
+     }
+ }
+ 
++static void MSSTYLES_ParseV4InheritanceMap(PTHEME_FILE tf)
++{
++    HRSRC hrsc;
++    DWORD size, *buf;
++    int imsize, imoffset, i;
++    THEME_CLASS **classes, *cls;
++
++    static const WCHAR BCMAPResource[] = {
++        'B','C','M','A','P',0
++    };
++
++    if(!(hrsc = FindResourceW(tf->hTheme, BCMAPResource, BCMAPResource))) {
++        WARN("No BCMAP resource found\n");
++        return;
++    }
++
++    size = SizeofResource(tf->hTheme, hrsc);
++    if (size < sizeof(DWORD)) {
++        WARN("Invalid inheritance map\n");
++        return;
++    }
++
++    buf = (DWORD*)LoadResource(tf->hTheme, hrsc);
++    if (!buf) {
++        WARN("Could not open inheritance map\n");
++        return;
++    }
++
++    if (size < ((buf[0] + 1) * sizeof(DWORD))) {
++        WARN("Inheritance map is truncated\n");
++        return;
++    }
++
++    imsize = buf[0];
++    imoffset = tf->numclassesv4 - imsize;
++    buf = &buf[1];
++
++    classes = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(THEME_CLASS*) * imsize);
++
++    cls = tf->classes;
++    while (cls) {
++        if (cls->classv4 >= imoffset && (cls->classv4 - imoffset) < imsize) {
++            classes[cls->classv4 - imoffset] = cls;
++        }
++        cls = cls->next;
++    }
++
++    for (i = 0; i < imsize; i++) {
++        if (classes[i] && buf[i] != 0xFFFFFFFF && classes[buf[i]]) {
++            classes[i]->parent = classes[buf[i]];
++            TRACE("%s has parent %s\n", debugstr_w(classes[i]->szClassName), debugstr_w(classes[i]->parent->szClassName));
++        }
++    }
++
++    HeapFree(GetProcessHeap(), 0, classes);
++}
++
+ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+ {
+     HRSRC hrsc;
+@@ -1232,6 +1290,7 @@ static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics)
+ 
+     MSSTYLES_ParseV4ClassMap(tf);
+     MSSTYLES_ParseV4Properties(tf, variant_name);
++    MSSTYLES_ParseV4InheritanceMap(tf);
+ }
+ 
+ /***********************************************************************
+@@ -1433,7 +1492,7 @@ HRESULT MSSTYLES_CloseThemeClass(PTHEME_CLASS tc)
+  * preference, but may be ignored in the attempt to locate the property.
+  * Will scan the entire chain of overrides for this class.
+  */
+-PTHEME_PROPERTY MSSTYLES_FindProperty(PTHEME_CLASS tc, int iPartId, int iStateId, int iPropertyPrimitive, int iPropertyId)
++static PTHEME_PROPERTY MSSTYLES_FindProperty2(PTHEME_CLASS tc, int iPartId, int iStateId, int iPropertyPrimitive, int iPropertyId)
+ {
+     PTHEME_CLASS next = tc;
+     PTHEME_PARTSTATE ps;
+@@ -1455,11 +1514,23 @@ PTHEME_PROPERTY MSSTYLES_FindProperty(PTHEME_CLASS tc, int iPartId, int iStateId
+     else
+         return NULL;
+ 
+-    if((tp = MSSTYLES_FindProperty(tc, iPartId, iStateId, iPropertyPrimitive, iPropertyId)))
++    if((tp = MSSTYLES_FindProperty2(tc, iPartId, iStateId, iPropertyPrimitive, iPropertyId)))
+         return tp;
+     return NULL;
+ }
+ 
++PTHEME_PROPERTY MSSTYLES_FindProperty(PTHEME_CLASS tc, int iPartId, int iStateId, int iPropertyPrimitive, int iPropertyId)
++{
++    PTHEME_PROPERTY tp;
++
++    if ((tp = MSSTYLES_FindProperty2(tc, iPartId, iStateId, iPropertyPrimitive, iPropertyId)))
++        return tp;
++    else if (tc->parent)
++        return MSSTYLES_FindProperty(tc->parent, iPartId, iStateId, iPropertyPrimitive, iPropertyId);
++    else
++        return NULL;
++}
++
+ /* Prepare a bitmap to be used for alpha blending */
+ static BOOL prepare_alpha (HBITMAP bmp, BOOL* hasAlpha)
+ {
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 822aae8..61a4e78 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -63,6 +63,7 @@ typedef struct _THEME_CLASS {
+     PTHEME_PARTSTATE partstate;
+     struct _THEME_CLASS *overrides;
+     int classv4;
++    struct _THEME_CLASS *parent;
+ 
+     struct _THEME_CLASS *next;
+ } THEME_CLASS, *PTHEME_CLASS;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0013-uxtheme-Parse-v4-size-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0013-uxtheme-Parse-v4-size-properties.patch
@@ -1,0 +1,40 @@
+From 3d297d901c57a96aa031b55983f548e77e7bc807 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:18:16 +0100
+Subject: [PATCH 13/19] uxtheme: Parse v4 size properties.
+
+---
+ dlls/uxtheme/msstyles.c | 4 ++++
+ dlls/uxtheme/msstyles.h | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index b672adc..2903889 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1054,6 +1054,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     memcpy(&prop->u.margins, &buf[i], min(sizeof(MARGINS), ph->datalen));
+                 break;
+ 
++                case TMT_SIZE:
++                    memcpy(&prop->u.size, &buf[i], min(sizeof(SIZE), ph->datalen));
++                break;
++
+                 default:
+                     FIXME("Unprocessed non-resource property type %u\n", ph->type);
+                 break;
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 61a4e78..8a9ad79 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -40,6 +40,7 @@ typedef struct _THEME_PROPERTY {
+         signed long integer;
+         COLORREF colour;
+         MARGINS margins;
++        SIZE size;
+     } u;
+ 
+     struct _THEME_PROPERTY *next;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0014-uxtheme-Parse-v4-rect-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0014-uxtheme-Parse-v4-rect-properties.patch
@@ -1,0 +1,73 @@
+From 818755b4df53bc1956e517946c4ae0757a82cb2c Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:33:37 +0100
+Subject: [PATCH 14/19] uxtheme: Parse v4 rect properties.
+
+---
+ dlls/uxtheme/msstyles.c | 23 +++++++++++++++++++++--
+ dlls/uxtheme/msstyles.h |  1 +
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 2903889..09d1d3e 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1058,6 +1058,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     memcpy(&prop->u.size, &buf[i], min(sizeof(SIZE), ph->datalen));
+                 break;
+ 
++                case TMT_RECT:
++                    memcpy(&prop->u.rect, &buf[i], min(sizeof(RECT), ph->datalen));
++                break;
++
+                 default:
+                     FIXME("Unprocessed non-resource property type %u\n", ph->type);
+                 break;
+@@ -1084,6 +1088,21 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     prop->u.integer = ph->resref;
+                 break;
+ 
++                case TMT_RECT:
++                {
++                    WCHAR *lpCur = s, *lpEnd;
++
++                    LoadStringW(tf->hMUIFile, ph->resref, s, sizeof(s)/sizeof(*s));
++
++                    lpEnd = s + strlenW(s);
++
++                    MSSTYLES_GetNextInteger(lpCur, lpEnd, (LPCWSTR*)&lpCur, &prop->u.rect.left);
++                    MSSTYLES_GetNextInteger(lpCur, lpEnd, (LPCWSTR*)&lpCur, &prop->u.rect.top);
++                    MSSTYLES_GetNextInteger(lpCur, lpEnd, (LPCWSTR*)&lpCur, &prop->u.rect.right);
++                    MSSTYLES_GetNextInteger(lpCur, lpEnd, (LPCWSTR*)&lpCur, &prop->u.rect.bottom);
++                    break;
++                }
++
+                 default:
+                     FIXME("Unprocessed resource property type %u\n", ph->type);
+                 break;
+@@ -2019,8 +2038,8 @@ HRESULT MSSTYLES_GetPropertyRect(PTHEME_PROPERTY tp, RECT *pRect)
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        memcpy(pRect, &tp->u.rect, sizeof(RECT));
++        return S_OK;
+     }
+ 
+     MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &pRect->left);
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 8a9ad79..27e085f 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -41,6 +41,7 @@ typedef struct _THEME_PROPERTY {
+         COLORREF colour;
+         MARGINS margins;
+         SIZE size;
++        RECT rect;
+     } u;
+ 
+     struct _THEME_PROPERTY *next;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0015-uxtheme-Parse-v4-font-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0015-uxtheme-Parse-v4-font-properties.patch
@@ -1,0 +1,67 @@
+From 7854530ca7ae21490c0a750ff705833a277b94a4 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sun, 12 Apr 2015 18:42:24 +0100
+Subject: [PATCH 15/19] uxtheme: Parse v4 font properties.
+
+---
+ dlls/uxtheme/msstyles.c | 24 ++++++++++++++++++++++--
+ dlls/uxtheme/msstyles.h |  1 +
+ 2 files changed, 23 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index 75766f7..eae4a74 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1096,6 +1096,26 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     break;
+                 }
+ 
++                case TMT_FONT:
++                {
++                    WCHAR *lpCur = s, *lpEnd;
++
++                    LoadStringW(tf->hMUIFile, ph->resref, s, sizeof(s)/sizeof(*s));
++
++                    lpEnd = s + strlenW(s);
++
++                    memset(&prop->u.font, 0, sizeof(LOGFONTW));
++                    if (SUCCEEDED(MSSTYLES_GetFont(lpCur, lpEnd, (LPCWSTR*)&lpCur, &prop->u.font))) {
++                        HDC dc = GetDC(NULL);
++
++                        prop->u.font.lfHeight = -MulDiv(prop->u.font.lfHeight, GetDeviceCaps(dc, LOGPIXELSY), 72);
++
++                        ReleaseDC(NULL, dc);
++                    }
++
++                    break;
++                }
++
+                 default:
+                     FIXME("Unprocessed resource property type %u\n", ph->type);
+                 break;
+@@ -1925,8 +1945,8 @@ HRESULT MSSTYLES_GetPropertyFont(PTHEME_PROPERTY tp, HDC hdc, LOGFONTW *pFont)
+     HRESULT hr; 
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        memcpy(pFont, &tp->u.font, sizeof(LOGFONTW));
++        return S_OK;
+     }
+ 
+     ZeroMemory(pFont, sizeof(LOGFONTW));
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 27e085f..45d1e91 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -40,6 +40,7 @@ typedef struct _THEME_PROPERTY {
+         signed long integer;
+         COLORREF colour;
+         MARGINS margins;
++        LOGFONTW font;
+         SIZE size;
+         RECT rect;
+     } u;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0016-uxtheme-Parse-v4-system-metrics.patch
+++ b/patches/uxtheme-MSStylesV4/0016-uxtheme-Parse-v4-system-metrics.patch
@@ -1,0 +1,210 @@
+From f3dac5599adc4ae7215a14c805a1f9c19868375a Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:48:23 +0100
+Subject: [PATCH 16/19] uxtheme: Parse v4 system metrics.
+
+---
+ dlls/uxtheme/msstyles.c | 173 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 173 insertions(+)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index eae4a74..a9fa2ac 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1306,6 +1306,165 @@ static void parse_apply_nonclient (struct PARSENONCLIENTSTATE* state)
+     }
+ }
+ 
++static void parse_handle_colour_property_v4(struct PARSECOLORSTATE* state, PTHEME_PROPERTY prop)
++{
++    int i = state->colorCount;
++
++    state->colorElements[i] = prop->iPropertyId - TMT_FIRSTCOLOR;
++    state->colorRgb[i] = prop->u.colour;
++
++    state->colorCount++;
++
++    switch (prop->iPropertyId)
++    {
++        case TMT_ACTIVECAPTION:
++            state->captionColors |= 0x1;
++        break;
++
++        case TMT_INACTIVECAPTION:
++            state->captionColors |= 0x2;
++        break;
++
++        case TMT_GRADIENTACTIVECAPTION:
++            state->captionColors |= 0x4;
++        break;
++
++        case TMT_GRADIENTINACTIVECAPTION:
++            state->captionColors |= 0x8;
++        break;
++    }
++}
++
++static void parse_handle_nonclient_font_v4 (struct PARSENONCLIENTSTATE* state, PTHEME_PROPERTY prop)
++{
++    switch (prop->iPropertyId)
++    {
++        case TMT_CAPTIONFONT:
++            state->metrics.lfCaptionFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_SMALLCAPTIONFONT:
++            state->metrics.lfSmCaptionFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_MENUFONT:
++            state->metrics.lfMenuFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_STATUSFONT:
++            state->metrics.lfStatusFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_MSGBOXFONT:
++            state->metrics.lfMessageFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_ICONTITLEFONT:
++            state->iconTitleFont = prop->u.font;
++            state->metricsDirty = TRUE;
++        break;
++    }
++}
++
++static BOOL parse_handle_nonclient_size_v4 (struct PARSENONCLIENTSTATE* state, PTHEME_PROPERTY prop)
++{
++    switch (prop->iPropertyId)
++    {
++        case TMT_SIZINGBORDERWIDTH:
++            state->metrics.iBorderWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_SCROLLBARWIDTH:
++            state->metrics.iScrollWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_SCROLLBARHEIGHT:
++            state->metrics.iScrollHeight = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_CAPTIONBARWIDTH:
++            state->metrics.iCaptionWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_CAPTIONBARHEIGHT:
++            state->metrics.iCaptionHeight = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_SMCAPTIONBARWIDTH:
++            state->metrics.iSmCaptionWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_SMCAPTIONBARHEIGHT:
++            state->metrics.iSmCaptionHeight = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_MENUBARWIDTH:
++            state->metrics.iMenuWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_MENUBARHEIGHT:
++            state->metrics.iMenuHeight = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        case TMT_PADDEDBORDERWIDTH:
++            state->metrics.iPaddedBorderWidth = prop->u.size.cx;
++            state->metricsDirty = TRUE;
++        break;
++
++        default:
++            return FALSE;
++    }
++
++    return TRUE;
++}
++
++static void MSSTYLES_SetMetricsV4(PTHEME_CLASS cls)
++{
++    struct PARSECOLORSTATE colourstate;
++    struct PARSENONCLIENTSTATE nonclientstate;
++    PTHEME_PARTSTATE ps;
++    PTHEME_PROPERTY prop;
++
++    parse_init_color(&colourstate);
++    parse_init_nonclient (&nonclientstate);
++
++    ps = cls->partstate;
++    while (ps) {
++        if (ps->iPartId == 0 && ps->iStateId == 0) {
++            prop = ps->properties;
++            while (prop) {
++                if (prop->iPrimitiveType == TMT_COLOR) {
++                    parse_handle_colour_property_v4(&colourstate, prop);
++                } else if (prop->iPrimitiveType == TMT_FONT) {
++                    parse_handle_nonclient_font_v4(&nonclientstate, prop);
++                } else if (prop->iPrimitiveType == TMT_SIZE) {
++                    parse_handle_nonclient_size_v4(&nonclientstate, prop);
++                }
++                prop = prop->next;
++            }
++            break;
++        }
++        ps = ps->next;
++    }
++
++    parse_apply_nonclient(&nonclientstate);
++    parse_apply_color(&colourstate);
++}
++
+ static BOOL MSSTYLES_GetVariantName(PTHEME_FILE tf, WCHAR* variant_name)
+ {
+     if (!strcmpiW(tf->pszSelectedSize, tf->vmap.size) && !strcmpiW(tf->pszSelectedColor, tf->vmap.colour)) {
+@@ -1319,6 +1478,8 @@ static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics)
+ {
+     WCHAR variant_name[255];
+ 
++    static const WCHAR sysmetrics[] = {'s','y','s','m','e','t','r','i','c','s',0};
++
+     if (!MSSTYLES_GetVariantName(tf, variant_name)) {
+         WARN("Could not get variant name for selected size and colour\n");
+         return;
+@@ -1327,6 +1488,18 @@ static void MSSTYLES_ParseV4Theme(PTHEME_FILE tf, BOOL setMetrics)
+     MSSTYLES_ParseV4ClassMap(tf);
+     MSSTYLES_ParseV4Properties(tf, variant_name);
+     MSSTYLES_ParseV4InheritanceMap(tf);
++
++    if (setMetrics) {
++        PTHEME_CLASS cls = tf->classes;
++
++        while (cls) {
++            if (!strcmpiW(cls->szClassName, sysmetrics) && cls->szAppName[0] == 0) {
++                MSSTYLES_SetMetricsV4(cls);
++                break;
++            }
++            cls = cls->next;
++        }
++    }
+ }
+ 
+ /***********************************************************************
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0017-uxtheme-Parse-v4-position-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0017-uxtheme-Parse-v4-position-properties.patch
@@ -1,0 +1,51 @@
+From ea361412a594ef6b4cc0cf9f41b9ae4489575448 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:57:08 +0100
+Subject: [PATCH 17/19] uxtheme: Parse v4 position properties.
+
+---
+ dlls/uxtheme/msstyles.c | 8 ++++++--
+ dlls/uxtheme/msstyles.h | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index a9fa2ac..f7f16fb 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1051,6 +1051,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     memcpy(&prop->u.size, &buf[i], min(sizeof(SIZE), ph->datalen));
+                 break;
+ 
++                case TMT_POSITION:
++                    memcpy(&prop->u.point, &buf[i], min(sizeof(POINT), ph->datalen));
++                break;
++
+                 case TMT_RECT:
+                     memcpy(&prop->u.rect, &buf[i], min(sizeof(RECT), ph->datalen));
+                 break;
+@@ -2185,8 +2189,8 @@ HRESULT MSSTYLES_GetPropertyPosition(PTHEME_PROPERTY tp, POINT *pPoint)
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        memcpy(pPoint, &tp->u.point, sizeof(POINT));
++        return S_OK;
+     }
+ 
+     if(!MSSTYLES_GetNextInteger(lpCur, lpEnd, &lpCur, &x)) {
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index 45d1e91..cf3d057 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -41,6 +41,7 @@ typedef struct _THEME_PROPERTY {
+         COLORREF colour;
+         MARGINS margins;
+         LOGFONTW font;
++        POINT point;
+         SIZE size;
+         RECT rect;
+     } u;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0018-uxtheme-Parse-v4-intlist-properties.patch
+++ b/patches/uxtheme-MSStylesV4/0018-uxtheme-Parse-v4-intlist-properties.patch
@@ -1,0 +1,51 @@
+From b32f67cbe75a1ac83fbf8f243b8d3a9804bc1b17 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sat, 11 Apr 2015 23:58:53 +0100
+Subject: [PATCH 18/19] uxtheme: Parse v4 intlist properties.
+
+---
+ dlls/uxtheme/msstyles.c | 8 ++++++--
+ dlls/uxtheme/msstyles.h | 1 +
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/msstyles.c b/dlls/uxtheme/msstyles.c
+index f7f16fb..15b6ecb 100644
+--- a/dlls/uxtheme/msstyles.c
++++ b/dlls/uxtheme/msstyles.c
+@@ -1059,6 +1059,10 @@ void MSSTYLES_ParseV4Properties(PTHEME_FILE tf, const WCHAR* variant_name)
+                     memcpy(&prop->u.rect, &buf[i], min(sizeof(RECT), ph->datalen));
+                 break;
+ 
++                case TMT_INTLIST:
++                    prop->u.intlist = (INTLIST*)&buf[i];
++                break;
++
+                 default:
+                     FIXME("Unprocessed non-resource property type %u\n", ph->type);
+                 break;
+@@ -2165,8 +2169,8 @@ HRESULT MSSTYLES_GetPropertyIntList(PTHEME_PROPERTY tp, INTLIST *pIntList)
+     LPCWSTR lpEnd = tp->lpValue + tp->dwValueLen;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        memcpy(pIntList, tp->u.intlist, sizeof(INTLIST));
++        return S_OK;
+     }
+ 
+     for(i=0; i < MAX_INTLIST_COUNT; i++) {
+diff --git a/dlls/uxtheme/msstyles.h b/dlls/uxtheme/msstyles.h
+index cf3d057..1321ea9 100644
+--- a/dlls/uxtheme/msstyles.h
++++ b/dlls/uxtheme/msstyles.h
+@@ -44,6 +44,7 @@ typedef struct _THEME_PROPERTY {
+         POINT point;
+         SIZE size;
+         RECT rect;
++        INTLIST* intlist;
+     } u;
+ 
+     struct _THEME_PROPERTY *next;
+-- 
+2.0.5
+

--- a/patches/uxtheme-MSStylesV4/0019-uxtheme-Implement-GetThemeMetric-for-v4-themes.patch
+++ b/patches/uxtheme-MSStylesV4/0019-uxtheme-Implement-GetThemeMetric-for-v4-themes.patch
@@ -1,0 +1,56 @@
+From fedb6517eef718f91ed4171c5a41901638bf6a46 Mon Sep 17 00:00:00 2001
+From: Mark Harmstone <mark@harmstone.com>
+Date: Sun, 12 Apr 2015 00:00:22 +0100
+Subject: [PATCH 19/19] uxtheme: Implement GetThemeMetric for v4 themes.
+
+---
+ dlls/uxtheme/property.c | 33 +++++++++++++++++++++++++++++++--
+ 1 file changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/uxtheme/property.c b/dlls/uxtheme/property.c
+index aace3d5..3ab0b1b 100644
+--- a/dlls/uxtheme/property.c
++++ b/dlls/uxtheme/property.c
+@@ -263,8 +263,37 @@ HRESULT WINAPI GetThemeMetric(HTHEME hTheme, HDC hdc, int iPartId,
+         return E_PROP_ID_UNSUPPORTED;
+ 
+     if (tp->version == 4) {
+-        FIXME("Not yet supported for v4 themes\n");
+-        return E_NOTIMPL;
++        switch (tp->iPrimitiveType) {
++            case TMT_INT:
++            case TMT_BOOL:
++            case TMT_ENUM:
++                *piVal = tp->u.integer;
++                return S_OK;
++
++            case TMT_COLOR:
++                *piVal = tp->u.colour;
++                return S_OK;
++
++            case TMT_SIZE:
++                *piVal = tp->u.size.cx;
++                return S_OK;
++
++            case TMT_POSITION:
++                *piVal = tp->u.point.x;
++                return S_OK;
++
++            case TMT_MARGINS:
++                *piVal = tp->u.margins.cxLeftWidth;
++                return S_OK;
++
++            case TMT_INTLIST:
++                *piVal = tp->u.intlist->iValues[0];
++                return S_OK;
++
++            default:
++                FIXME("Unsupported primitive type %u\n", tp->iPrimitiveType);
++                break;
++        }
+     } else {
+         switch(tp->iPrimitiveType) {
+             case TMT_POSITION: /* Only the X coord is retrieved */
+-- 
+2.0.5
+


### PR DESCRIPTION
Sorry, I've just noticed a bug in patch 15 - the LOGFONT needs to be memset first, MSSTYLES_GetFont doesn't do it. If a corrupted LOGFONT gets into the WindowMetrics key, it can cause all GUI applications to crash on startup.