### PR TITLE
advapi32: LsaLookupPrivilegeName: check for pointer in WellKnownPrivNames

### DIFF
--- a/patches/advapi-LsaLookupPrivilegeName/0003-advapi32-Implement-LsaLookupPrivilegeName.patch
+++ b/patches/advapi-LsaLookupPrivilegeName/0003-advapi32-Implement-LsaLookupPrivilegeName.patch
@@ -1,4 +1,4 @@
-From bee5e0baac722c66ad8c1034a65a2cecfe74716e Mon Sep 17 00:00:00 2001
+From fcefc5661656de44d02fed0431b4a61fa618b663 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Michael=20M=C3=BCller?= <michael@fds-team.de>
 Date: Sun, 5 Mar 2017 23:50:06 +0100
 Subject: advapi32: Implement LsaLookupPrivilegeName.
@@ -6,13 +6,13 @@ Subject: advapi32: Implement LsaLookupPrivilegeName.
 ---
  dlls/advapi32/advapi32.spec   |  2 +-
  dlls/advapi32/advapi32_misc.h |  2 ++
- dlls/advapi32/lsa.c           | 38 ++++++++++++++++++++++++++++++++++++++
+ dlls/advapi32/lsa.c           | 39 +++++++++++++++++++++++++++++++++++++++
  dlls/advapi32/security.c      | 27 ++++++++++++++++++---------
  include/ntsecapi.h            |  1 +
- 5 files changed, 60 insertions(+), 10 deletions(-)
+ 5 files changed, 61 insertions(+), 10 deletions(-)
 
 diff --git a/dlls/advapi32/advapi32.spec b/dlls/advapi32/advapi32.spec
-index 078bb8fc25..124f527282 100644
+index d5503490a0..709a385967 100644
 --- a/dlls/advapi32/advapi32.spec
 +++ b/dlls/advapi32/advapi32.spec
 @@ -469,7 +469,7 @@
@@ -36,10 +36,10 @@ index d116ecb836..ecb07f635a 100644
 +
  #endif /* __WINE_ADVAPI32MISC_H */
 diff --git a/dlls/advapi32/lsa.c b/dlls/advapi32/lsa.c
-index 479201bfc1..ceb3b05c05 100644
+index 3da6d19b82..af5f9dd46d 100644
 --- a/dlls/advapi32/lsa.c
 +++ b/dlls/advapi32/lsa.c
-@@ -973,3 +973,41 @@ NTSTATUS WINAPI LsaUnregisterPolicyChangeNotification(
+@@ -973,3 +973,42 @@ NTSTATUS WINAPI LsaUnregisterPolicyChangeNotification(
      FIXME("(%d,%p) stub\n", class, event);
      return STATUS_SUCCESS;
  }
@@ -67,7 +67,8 @@ index 479201bfc1..ceb3b05c05 100644
 +
 +    if (lpLuid->HighPart ||
 +        (lpLuid->LowPart < SE_MIN_WELL_KNOWN_PRIVILEGE ||
-+         lpLuid->LowPart > SE_MAX_WELL_KNOWN_PRIVILEGE))
++         lpLuid->LowPart > SE_MAX_WELL_KNOWN_PRIVILEGE ||
++         !WellKnownPrivNames[lpLuid->LowPart]))
 +        return STATUS_NO_SUCH_PRIVILEGE;
 +
 +    priv_size = (strlenW(WellKnownPrivNames[lpLuid->LowPart]) + 1) * sizeof(WCHAR);
@@ -158,5 +159,5 @@ index 2bb3d312e4..0bf0eca43e 100644
  ULONG WINAPI LsaNtStatusToWinError(NTSTATUS);
  NTSTATUS WINAPI LsaOpenPolicy(PLSA_UNICODE_STRING,PLSA_OBJECT_ATTRIBUTES,ACCESS_MASK,PLSA_HANDLE);
 -- 
-2.11.0
+2.13.1
 


### PR DESCRIPTION
It fixes a crash in Dead Space.

Also note: the LsaLookupPrivilegeName() most probably should not check for `handle` and `name` being null, because it's internal function, and the only place where it's used guarantees to pass a valid pointer. Instead it should use `assert`. I am unfortunately failed to make the changes: for unknown reasons compilation issues a weird error about undefined reference to `assert()`. I hope somebody more acknowledgeable can make this working — the change is trivial, I just really don't know what's up with the error.